### PR TITLE
ziggurat: fix `%ziggurat-action` json `+grab`

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -110,7 +110,7 @@
             next-contract-id=0xfafa.faf0
             error=~
             state=(starting-state user-address.act)
-            data-texts=(malt ~[[id.p:(designated-zigs-item user-address.act) '[balance=300.000.000.000.000.000.000 allowances=~ metadata=0x61.7461.6461.7465.6d2d.7367.697a]']])
+            noun-data-texts=(malt ~[[id.p:(designated-zigs-item user-address.act) '[balance=300.000.000.000.000.000.000 allowances=~ metadata=0x61.7461.6461.7465.6d2d.7367.697a]']])
             user-address.act
             user-nonce=0
             batch-num=0
@@ -231,8 +231,8 @@
         %+  put:big:engine  p.chain.project
         [id.data %&^data]
       ::
-          data-texts.project
-        (~(put by data-texts.project) id.data data-text)
+          noun-data-texts.project
+        (~(put by noun-data-texts.project) id.data data-text)
       ==
       :-  (make-project-update project.act project)^~
       state(projects (~(put by projects) project.act project))
@@ -529,17 +529,21 @@
     (project-to-json project)
   ::
       [%project-state @ ~]
-    ?~  project=(~(get by projects) (slav %t i.t.t.path))
+    ?~  project=(~(get by projects) i.t.t.path)
       ``json+!>(~)
-    =/  =json  (state-to-json p.chain.u.project data-texts.u.project)
+    =/  =json  (state-to-json p.chain.u.project noun-data-texts.u.project)
     ``json+!>(json)
   ::
       [%project-tests @ ~]
-    ?~  project=(~(get by projects) (slav %t i.t.t.path))
+    ?~  project=(~(get by projects) i.t.t.path)
       ``json+!>(~)
-    ?>  ?=(%& -.u.project)
     =/  =json  (tests-to-json tests.u.project)
     ``json+!>(json)
+  ::
+      [%project-user-files @ ~]
+    ?~  project=(~(get by projects) i.t.t.path)
+      ``json+!>(~)
+    ``json+!>(`json`(user-files-to-json user-files.u.project))
   ::
       [%file-exists @ ^]
     =/  des=@ta    i.t.t.path

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -110,7 +110,7 @@
             next-contract-id=0xfafa.faf0
             error=~
             state=(starting-state user-address.act)
-            noun-data-texts=(malt ~[[id.p:(designated-zigs-item user-address.act) '[balance=300.000.000.000.000.000.000 allowances=~ metadata=0x61.7461.6461.7465.6d2d.7367.697a]']])
+            noun-texts=(malt ~[[id.p:(designated-zigs-item user-address.act) '[balance=300.000.000.000.000.000.000 allowances=~ metadata=0x61.7461.6461.7465.6d2d.7367.697a]']])
             user-address.act
             user-nonce=0
             batch-num=0
@@ -231,8 +231,8 @@
         %+  put:big:engine  p.chain.project
         [id.data %&^data]
       ::
-          noun-data-texts.project
-        (~(put by noun-data-texts.project) id.data data-text)
+          noun-texts.project
+        (~(put by noun-texts.project) id.data data-text)
       ==
       :-  (make-project-update project.act project)^~
       state(projects (~(put by projects) project.act project))
@@ -531,7 +531,7 @@
       [%project-state @ ~]
     ?~  project=(~(get by projects) i.t.t.path)
       ``json+!>(~)
-    =/  =json  (state-to-json p.chain.u.project noun-data-texts.u.project)
+    =/  =json  (state-to-json p.chain.u.project noun-texts.u.project)
     ``json+!>(json)
   ::
       [%project-tests @ ~]

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -51,6 +51,7 @@
   =/  =path  /project/[project-name]
   =/  update=project-update
     :*  dir.p
+        user-files.p
         ?=(~ errors.p)
         errors.p
         chain.p

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -54,7 +54,7 @@
         ?=(~ errors.p)
         errors.p
         chain.p
-        data-texts.p
+        noun-data-texts.p
         tests.p
     ==
   :^  %give  %fact  ~[path]
@@ -381,8 +381,8 @@
       tests
     (malt ~[[0x1111.1111 test-1] [0x2222.2222 test-2] [0x3333.3333 test-3]])
   ::
-      data-texts
-    %-  ~(uni by data-texts.current)
+      noun-data-texts
+    %-  ~(uni by noun-data-texts.current)
     %-  ~(gas by *(map id:smart @t))
     :~  [id.meta-rice ;;(@t noun.meta-rice)]
         [dead-beef-account-id '[balance=200 allowances=~ metadata=0xdada.dada nonce=0]']
@@ -588,8 +588,8 @@
       tests
     (malt ~[[0x1111.1111 test-1] [0x2222.2222 test-2] [0x3333.3333 test-3]])
   ::
-      data-texts
-    %-  ~(uni by data-texts.current)
+      noun-data-texts
+    %-  ~(uni by noun-data-texts.current)
     %-  ~(gas by *(map id:smart @t))
     :~  [id.meta-rice ;;(@t noun.meta-rice)]
         ::  [1 'https://image.link' id.meta-rice ~ props &]
@@ -681,16 +681,16 @@
   ^-  json
   %-  pairs
   %+  welp
-    :~  ['source' %s (scot %ux source.p.item)]
+    :~  ['is-pact' %b ?=(%| -.item)]
+        ['source' %s (scot %ux source.p.item)]
         ['holder' %s (scot %ux holder.p.item)]
         ['town' %s (scot %ux town.p.item)]
     ==
-  ?.  ?=(%& -.item)
-    ['contract' %b %.y]~
+  ?:  ?=(%| -.item)  ~
   :~  ['salt' (numb salt.p.item)]
       ['label' %s (scot %tas label.p.item)]
-      ['data_text' %s tex]
-      ['data' %s (crip (noah !>(noun.p.item)))]
+      ['noun_text' %s tex]
+      ['noun' %s (crip (noah !>(noun.p.item)))]  ::  TODO: remove?
   ==
 ::
 ++  project-to-json
@@ -703,12 +703,12 @@
       ['to_compile' (to-compile-to-json to-compile.p)]
       ['next_contract_id' %s (scot %ux next-contract-id.p)]
       ['errors' (errors-to-json errors.p)]
-      ['state' (state-to-json p.chain.p data-texts.p)]
+      ['state' (state-to-json p.chain.p noun-data-texts.p)]
       ['tests' (tests-to-json tests.p)]
   ==
 ::
 ++  state-to-json
-  |=  [=state:engine data-texts=(map id:smart @t)]
+  |=  [=state:engine noun-data-texts=(map id:smart @t)]
   ::
   ::  ignoring/not printing nonces for now.
   ::
@@ -719,8 +719,7 @@
   |=  [=id:smart merk=@ux =item:smart]
   ::  ignore contract nock -- just print metadata
   :-  (scot %ux id)
-  %+  item-to-json  item
-  ?~(t=(~(get by data-texts) id) '' u.t)
+  (item-to-json item (~(gut by noun-data-texts) id ''))
 ::
 ++  tests-to-json
   |=  =tests
@@ -739,7 +738,7 @@
   :~  ['name' %s ?~(name.test '' u.name.test)]
       ['for_contract' %s (scot %ux for-contract.test)]  ::  TODO: to contract path?
       ['action_text' %s action-text.test]
-      ['action' %s (crip (noah !>(action.test)))]
+      ['action' %s (crip (noah !>(action.test)))]  ::  TODO: remove?
       ['expected' (expected-to-json expected.test)]
       ['expected_error' ?~(expected-error.test n+'0' (numb expected-error.test))]
       ['result' ?~(result.test ~ (test-result-to-json u.result.test))]
@@ -826,4 +825,14 @@
   :+  ['path' (path p)]
     ['error' %s error]
   ~
+::
+++  user-files-to-json
+  |=  user-files=(set path)
+  ^-  json
+  =/  user-files-list=(list path)  ~(tap by user-files)
+  ?~  user-files-list  ~
+  %+  frond:enjs:format  %user-files
+  :-  %a
+  %+  turn  user-files-list
+  |=([p=path] (path:enjs:format p))
 --

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -186,7 +186,7 @@
     |=  [face=term =path]
     ^-  hoon
     :+  %ktts  face
-    (rain path .^(@t %cx (welp desk (welp path /hoon))))
+    +:(parse-pile:conq (trip .^(@t %cx (welp desk (welp path /hoon)))))
   ::
   ++  build-libs  ::  third
     |=  braw=(list hoon)
@@ -537,7 +537,7 @@
         (trip (scot %ux user-address.current))
         " uri='https://image.link' "
         props-tape
-        " transferrable=&] ~]"
+        " transferrable=%.y] ~]"
     ==
   =/  yolk-3=calldata:smart
     =-  [;;(@tas -.-) +.-]

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -830,7 +830,7 @@
 ++  user-files-to-json
   |=  user-files=(set path)
   ^-  json
-  =/  user-files-list=(list path)  ~(tap by user-files)
+  =/  user-files-list=(list path)  ~(tap in user-files)
   ?~  user-files-list  ~
   %+  frond:enjs:format  %user-files
   :-  %a

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -55,7 +55,7 @@
         ?=(~ errors.p)
         errors.p
         chain.p
-        noun-data-texts.p
+        noun-texts.p
         tests.p
     ==
   :^  %give  %fact  ~[path]
@@ -382,8 +382,8 @@
       tests
     (malt ~[[0x1111.1111 test-1] [0x2222.2222 test-2] [0x3333.3333 test-3]])
   ::
-      noun-data-texts
-    %-  ~(uni by noun-data-texts.current)
+      noun-texts
+    %-  ~(uni by noun-texts.current)
     %-  ~(gas by *(map id:smart @t))
     :~  [id.meta-rice ;;(@t noun.meta-rice)]
         [dead-beef-account-id '[balance=200 allowances=~ metadata=0xdada.dada nonce=0]']
@@ -589,8 +589,8 @@
       tests
     (malt ~[[0x1111.1111 test-1] [0x2222.2222 test-2] [0x3333.3333 test-3]])
   ::
-      noun-data-texts
-    %-  ~(uni by noun-data-texts.current)
+      noun-texts
+    %-  ~(uni by noun-texts.current)
     %-  ~(gas by *(map id:smart @t))
     :~  [id.meta-rice ;;(@t noun.meta-rice)]
         ::  [1 'https://image.link' id.meta-rice ~ props &]
@@ -704,12 +704,12 @@
       ['to_compile' (to-compile-to-json to-compile.p)]
       ['next_contract_id' %s (scot %ux next-contract-id.p)]
       ['errors' (errors-to-json errors.p)]
-      ['state' (state-to-json p.chain.p noun-data-texts.p)]
+      ['state' (state-to-json p.chain.p noun-texts.p)]
       ['tests' (tests-to-json tests.p)]
   ==
 ::
 ++  state-to-json
-  |=  [=state:engine noun-data-texts=(map id:smart @t)]
+  |=  [=state:engine noun-texts=(map id:smart @t)]
   ::
   ::  ignoring/not printing nonces for now.
   ::
@@ -720,7 +720,7 @@
   |=  [=id:smart merk=@ux =item:smart]
   ::  ignore contract nock -- just print metadata
   :-  (scot %ux id)
-  (item-to-json item (~(gut by noun-data-texts) id ''))
+  (item-to-json item (~(gut by noun-texts) id ''))
 ::
 ++  tests-to-json
   |=  =tests

--- a/mar/ziggurat/action.hoon
+++ b/mar/ziggurat/action.hoon
@@ -17,10 +17,24 @@
       ==
     ++  process
       %-  of
-      :~  [%new-project ul]
+      :~  [%new-project (ot ~[[%user-address (se %ux)]])]
+          [%populate-template (ot ~[[%template (se %tas)] [%metadata parse-data]])]
           [%delete-project ul]
           [%save-file (ot ~[[%file pa] [%text so]])]
           [%delete-file (ot ~[[%file pa]])]
+          [%register-contract-for-compilation (ot ~[[%file pa]])]
+          [%compile-contracts ul]
+          [%read-desk ul]
+          [%add-to-state parse-data-without-id]
+          [%delete-from-state (ot ~[[%id (se %ux)]])]
+          [%add-test (ot ~[[%name so:dejs-soft:format] [%for-contract (se %ux)] [%action so] [%expected-error ni:dejs-soft:format]])]
+          [%add-test-expectation (ot ~[[%test-id (se %ux)] [%expected parse-data-without-id]])]
+          [%delete-test-expectation (ot ~[[%id (se %ux)] [%delete (se %ux)]])]
+          [%delete-test (ot ~[[%id (se %ux)]])]
+          [%edit-test (ot ~[[%id (se %ux)] [%name so:dejs-soft:format] [%for-contract (se %ux)] [%action so] [%expected-error ni:dejs-soft:format]])]
+          [%run-test parse-test]
+          [%run-tests (ar parse-test)]
+          [%deploy-contract parse-deploy]
           [%publish-app parse-docket]
       ==
     ::
@@ -33,6 +47,44 @@
           [%version (at ~[ni ni ni])]
           [%website so]
           [%license so]
+      ==
+    ::
+    ++  parse-data
+      %-  ot
+      :~  [%id (se %ux)]
+          [%source (se %ux)]
+          [%holder (se %ux)]
+          [%town (se %ux)]
+          [%salt ni]
+          [%label (se %tas)]
+          [%noun so]  ::  note: reaming to form noun
+      ==
+    ::
+    ++  parse-data-without-id
+      %-  ot
+      :~  [%source (se %ux)]
+          [%holder (se %ux)]
+          [%town (se %ux)]
+          [%salt ni]
+          [%label (se %tas)]
+          [%noun so]
+      ==
+    ::
+    ++  parse-test
+      %-  ot
+      :~  [%id (se %ux)]
+          [%rate ni]
+          [%bud ni]
+      ==
+    ::
+    ++  parse-deploy
+      %-  ot
+      :~  [%address (se %ux)]
+          [%rate ni]
+          [%bud ni]
+          [%deploy-location (se %tas)]
+          [%town-id (se %ux)]
+          [%upgradable bo]
       ==
     --
   --

--- a/mar/ziggurat/project-update.hoon
+++ b/mar/ziggurat/project-update.hoon
@@ -13,7 +13,7 @@
     %-  pairs
     :~  ['dir' (dir-to-json dir.upd)]
         ['compiled' [%b compiled.upd]]
-        ['errors' [%a errors.upd]]
+        ['errors' (errors-to-json errors.upd)]
         ['state' (state-to-json p.chain.upd data-texts.upd)]
         ['tests' (tests-to-json tests.upd)]
     ==

--- a/mar/ziggurat/project-update.hoon
+++ b/mar/ziggurat/project-update.hoon
@@ -12,6 +12,7 @@
     ^-  ^json
     %-  pairs
     :~  ['dir' (dir-to-json dir.upd)]
+        ['user_files' (user-files-to-json user-files.upd)]
         ['compiled' [%b compiled.upd]]
         ['errors' (errors-to-json errors.upd)]
         ['state' (state-to-json p.chain.upd data-texts.upd)]

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -11,7 +11,7 @@
       next-contract-id=id:smart
       errors=(list [path @t])
       =chain:engine
-      data-texts=(map id:smart @t)  ::  holds rice data that got ream'd
+      noun-data-texts=(map id:smart @t)  ::  holds `noun.data` that got ream'd
       user-address=address:smart
       user-nonce=@ud
       batch-num=@ud
@@ -89,7 +89,7 @@
       compiled=?
       errors=(list [path @t])
       =chain:engine
-      data-texts=(map id:smart @t)
+      noun-data-texts=(map id:smart @t)
       =tests
   ==
 ::

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -86,6 +86,7 @@
 ::
 +$  project-update
   $:  dir=(list path)
+      user-files=(set path)
       compiled=?
       errors=(list [path @t])
       =chain:engine

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -11,7 +11,7 @@
       next-contract-id=id:smart
       errors=(list [path @t])
       =chain:engine
-      noun-data-texts=(map id:smart @t)  ::  holds `noun.data` that got ream'd
+      noun-texts=(map id:smart @t)  ::  holds `noun.data` that got ream'd
       user-address=address:smart
       user-nonce=@ud
       batch-num=@ud
@@ -90,7 +90,7 @@
       compiled=?
       errors=(list [path @t])
       =chain:engine
-      noun-data-texts=(map id:smart @t)
+      noun-texts=(map id:smart @t)
       =tests
   ==
 ::

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -59,11 +59,11 @@
           [%compile-contracts ~]  ::  alterations to project files call %compile-contracts which calls %read-desk which sends a project update; TODO: skip compile when no change?
           [%read-desk ~]
           ::
-          [%add-to-state salt=@ label=@tas noun=* source=id:smart holder=id:smart town-id=@ux]
+          [%add-to-state source=id:smart holder=id:smart town-id=@ux salt=@ label=@tas noun=*]
           [%delete-from-state =id:smart]
           ::
           [%add-test name=(unit @t) for-contract=id:smart action=@t expected-error=(unit @ud)]  ::  name optional
-          [%add-test-expectation test-id=@ux salt=@ label=@tas noun=* source=id:smart holder=id:smart town-id=@ux]
+          [%add-test-expectation test-id=@ux source=id:smart holder=id:smart town-id=@ux salt=@ label=@tas noun=*]
           [%delete-test-expectation id=@ux delete=id:smart]
           [%delete-test id=@ux]
           [%edit-test id=@ux name=(unit @t) for-contract=id:smart action=@t expected-error=(unit @ud)]


### PR DESCRIPTION
FYI @willbach @0x70b1a5 should work now. If there are other pokes not working, let me know and I'll add them here. I specifically tested:

```hoon
:ziggurat &ziggurat-action [%foo %new-project 0x1234.5678]

:ziggurat &ziggurat-action [%foo %populate-template %nft [0xdead.beef.cafe 0xcafe.babe 0xcafe.babe 0x0 `@`%nft-metadata %token-metadata '[%foonft %foo (make-pset `(list @tas)`~[%hat %eyes]) 1 ~ %.y ~ 0x1234.5678 `@`%foonft-salt]']]
```

and bash equivalents:

```bash
curl --cookie "$NEC_COOKIE" --header 'content-type: application/json' -X PUT localhost:8083/~/channel/1 --data '[{"id": 1, "action": "poke", "ship": "nec", "app": "ziggurat", "mark": "ziggurat-action", "json": {"project": "foo", "action": {"new-project": {"user-address": "0x1234.5678"}}}}]'

curl --cookie "$NEC_COOKIE" --header 'content-type: application/json' -X PUT localhost:8083/~/channel/1 --data '[{"id": 3, "action": "poke", "ship": "nec", "app": "ziggurat", "mark": "ziggurat-action", "json": {"project": "foo", "action": {"populate-template": {"template": "nft", "metadata": {"id": "0xdead.beef.cafe", "source": "0xcafe.babe", "holder": "0xcafe.babe", "town": "0x0", "salt": 30160741268991363615676458606, "label": "token-metadata", "noun": "[%foonft %foo (make-pset `(list @tas)`~[%hat %eyes]) 1 ~ %.y ~ 0x1234.5678 `@`%foonft-salt]"}}}}}]'
```