### PR TITLE
indexer: refactor some names

### DIFF
--- a/app/sequencer.hoon
+++ b/app/sequencer.hoon
@@ -141,7 +141,7 @@
       ?.  =(%available status.state)
         ~|("%sequencer: error: got transaction while not active" !!)
       =/  received=^mempool
-        %-  ~(run in txns.act)
+        %-  ~(run in txs.act)
         |=  t=transaction:smart
         [`@ux`(sham +.t) t]
       ::  give a "receipt" to sender, with signature they can show

--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -244,17 +244,20 @@
         ::  forward a transaction to sequencer we're tracking
         ::  for the specified town
         ?>  =(src.bowl our.bowl)
-        ?~  seq=(~(get by sequencers.state) `@ux`town.txn.write)
+        ?~  seq=(~(get by sequencers.state) `@ux`town.transaction.write)
           ~|("%uqbar: no known sequencer for that town" !!)
-        =/  txn-hash  (scot %ux `@ux`(sham +.txn.write))
+        =/  transaction-hash
+          (scot %ux `@ux`(sham +.transaction.write))
         :_  state
-        :+  %+  ~(poke pass:io /submit-transaction/txn-hash)
+        :+  %+  %~  poke  pass:io
+                /submit-transaction/[transaction-hash]
               [q.u.seq %sequencer]
             :-  %sequencer-town-action
-            !>(`town-action:s`[%receive (silt ~[txn.write])])
+            !>  ^-  town-action:s
+            [%receive (silt ~[transaction.write])]
           %+  fact:io
             [%write-result !>(`write-result:u`[%sent ~])]
-          ~[/track/[txn-hash]]
+          ~[/track/[transaction-hash]]
         ~
       ::
           %receipt
@@ -263,7 +266,7 @@
         :_  ~
         %+  fact:io
           [%write-result !>(`write-result:u`write)]
-        ~[/track/(scot %ux txn-hash.write)]
+        ~[/track/(scot %ux transaction-hash.write)]
       ==
     --
   ::

--- a/lib/zig/indexer.hoon
+++ b/lib/zig/indexer.hoon
@@ -56,8 +56,8 @@
         %batch-order
       (frond %batch-order (batch-order batch-order.update))
     ::
-        %txn
-      (frond %txn (txns txns.update))
+        %transaction
+      (frond %transaction (transactions transactions.update))
     ::
         %item
       (frond %item (items items.update))
@@ -66,7 +66,7 @@
       %+  frond  %hash
       %-  pairs
       :^    [%batches (batches batches.update)]
-          [%txns (txns txns.update)]
+          [%transactions (transactions transactions.update)]
         [%items (items items.update)]
       ~
     ::
@@ -77,8 +77,8 @@
       %+  frond  %newest-batch-order
       (frond %batch-id %s (scot %ux batch-id.update))
     ::
-        %newest-txn
-      (frond %newest-txn (newest-txn +.update))
+        %newest-transaction
+      (frond %newest-transaction (newest-transaction +.update))
     ::
         %newest-item
       (frond %newest-item (newest-item +.update))
@@ -99,13 +99,13 @@
       [%batch-root %s (scot %ux batch-root.batch-location)]
     ~
   ::
-  ++  txn-location
-    |=  =txn-location:ui
+  ++  transaction-location
+    |=  location=transaction-location:ui
     ^-  json
     %-  pairs
-    :^    [%town-id %s (scot %ux town-id.txn-location)]
-        [%batch-root %s (scot %ux batch-root.txn-location)]
-      [%txn-num (numb txn-num.txn-location)]
+    :^    [%town-id %s (scot %ux town-id.location)]
+        [%batch-root %s (scot %ux batch-root.location)]
+      [%transaction-num (numb transaction-num.location)]
     ~
   ::
   ++  batches
@@ -135,64 +135,64 @@
     |=  =batch:ui
     ^-  json
     %-  pairs
-    :+  [%transactions (transactions transactions.batch)]
+    :+  [%transactions (processed-txs transactions.batch)]
       [%town (town +.batch)]
     ~
   ::
-  ++  transactions
-    |=  transactions=processed-txs:eng
+  ++  processed-txs
+    |=  =processed-txs:eng
     ^-  json
     :-  %a
-    %+  turn  transactions
+    %+  turn  processed-txs
     |=  [hash=@ux t=transaction:smart o=output:eng]
     %-  pairs
     :^    [%hash %s (scot %ux hash)]
-        [%txn (txn t)]
+        [%transaction (transaction t)]
       [%output (output o)]
     ~
   ::
-  ++  txns
-    |=  txns=(map txn-id=id:smart txn-update-value:ui)
+  ++  transactions
+    |=  transactions=(map transaction-id=id:smart transaction-update-value:ui)
     ^-  json
     %-  pairs
-    %+  turn  ~(tap by txns)
+    %+  turn  ~(tap by transactions)
     |=  $:  =id:smart
             timestamp=@da
-            location=txn-location:ui
+            location=transaction-location:ui
             t=transaction:smart
             o=output:eng
         ==
     :-  (scot %ux id)
     %-  pairs
     :~  [%timestamp (sect timestamp)]
-        [%location (txn-location location)]
-        [%txn (txn t)]
+        [%location (transaction-location location)]
+        [%transaction (transaction t)]
         [%output (output o)]
     ==
   ::
-  ++  newest-txn
+  ++  newest-transaction
     |=  $:  =id:smart
             timestamp=@da
-            location=txn-location:ui
+            location=transaction-location:ui
             t=transaction:smart
             o=output:eng
         ==
     ^-  json
     %-  pairs
-    :~  [%txn-id %s (scot %ux id)]
+    :~  [%transaction-id %s (scot %ux id)]
         [%timestamp (sect timestamp)]
-        [%location (txn-location location)]
-        [%txn (txn t)]
+        [%location (transaction-location location)]
+        [%transaction (transaction t)]
         [%output (output o)]
     ==
   ::
-  ++  txn
-    |=  txn=transaction:smart
+  ++  transaction
+    |=  =transaction:smart
     ^-  json
     %-  pairs
-    :^    [%sig (sig sig.txn)]
-        [%shell (shell +.+.txn)]
-      [%calldata (calldata calldata.txn contract.txn)]
+    :^    [%sig (sig sig.transaction)]
+        [%shell (shell +.+.transaction)]
+      [%calldata (calldata [calldata contract]:transaction)]
     ~
   ::
   ++  output

--- a/lib/zig/indexer.hoon
+++ b/lib/zig/indexer.hoon
@@ -96,7 +96,7 @@
     ^-  json
     %-  pairs
     :+  [%town-id %s (scot %ux town-id.batch-location)]
-      [%batch-root %s (scot %ux batch-root.batch-location)]
+      [%batch-id %s (scot %ux batch-id.batch-location)]
     ~
   ::
   ++  transaction-location
@@ -104,7 +104,7 @@
     ^-  json
     %-  pairs
     :^    [%town-id %s (scot %ux town-id.location)]
-        [%batch-root %s (scot %ux batch-root.location)]
+        [%batch-id %s (scot %ux batch-id.location)]
       [%transaction-num (numb transaction-num.location)]
     ~
   ::
@@ -435,8 +435,8 @@
     ^-  json
     :-  %a
     %+  turn  batch-order
-    |=  batch-root=id:smart
-    [%s (scot %ux batch-root)]
+    |=  batch-id=id:smart
+    [%s (scot %ux batch-id)]
   ::
   ++  tas-to-json
     |=  mapping=(map @tas json)

--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -4,7 +4,7 @@
     +$  card  card:agent:gall
     --
 |%
-++  hash-txn
+++  hash-transaction
   |=  [=calldata:smart =shell:smart]
   ::  hash the immutable+unique aspects of a transaction
   `@ux`(sham [calldata shell])
@@ -18,18 +18,18 @@
 ++  get-sent-history
   |=  [=address:smart newest=? our=@p now=@da]
   ^-  (map @ux [transaction:smart supported-actions])
-  =/  txn-history=update:ui
+  =/  transaction-history=update:ui
     .^  update:ui
         %gx
         %+  weld  /(scot %p our)/indexer/(scot %da now)
         %+  weld  ?.  newest  /  /newest
         /from/0x0/(scot %ux address)/noun
     ==
-  ?~  txn-history  ~
-  ?.  ?=(%txn -.txn-history)  ~
-  %-  ~(urn by txns.txn-history)
-  |=  [hash=@ux upd=[@ * txn=transaction:smart *]]  ::  if desired, where to add output:eng
-  [txn.upd(status (add 200 `@`status.txn.upd)) [%noun calldata.txn.upd]]
+  ?~  transaction-history  ~
+  ?.  ?=(%transaction -.transaction-history)  ~
+  %-  ~(urn by transactions.transaction-history)
+  |=  [hash=@ux @ * =transaction:smart *]  ::  if desired, where to add output:eng
+  [transaction(status (add 200 `@`status.transaction)) [%noun calldata.transaction]]
 ::
 ++  watch-for-batches
   |=  [our=@p town=@ux]
@@ -168,11 +168,11 @@
     (get-tracked-account-sent-txs accounts our now)
   =^  cardss=(list (list card))  transaction-store
     %^  spin  ~(tap by txs)  transaction-store
-    |=  [[account-id=@ux account-txs=(list [tx-id=@ux txn=transaction:smart action=supported-actions])] txs=^transaction-store]
+    |=  [[account-id=@ux account-txs=(list [tx-id=@ux =transaction:smart action=supported-actions])] txs=^transaction-store]
     =|  account-cards=(list card)
     =/  old-account-txs
       (~(gut by txs) account-id [sent=~ received=~])
-    =/  processed-account-txs=(map @ux [txn=transaction:smart action=supported-actions])
+    =/  processed-account-txs=(map @ux [=transaction:smart action=supported-actions])
       sent.old-account-txs
     |-
     ?~   account-txs
@@ -183,22 +183,22 @@
         (~(uni by sent.old-account-txs) processed-account-txs)
       ==
     =*  tx-id   tx-id.i.account-txs
-    =*  txn     txn.i.account-txs
+    =*  tx      transaction.i.account-txs
     =*  action  action.i.account-txs
     %=  $
         account-txs  t.account-txs
         processed-account-txs
       ?.  (~(has by processed-account-txs) tx-id)
         processed-account-txs
-      (~(put by processed-account-txs) tx-id [txn action])
+      (~(put by processed-account-txs) tx-id [tx action])
     ::
         account-cards
       :_  account-cards
       ?~  this-tx=(~(get by processed-account-txs) tx-id)
         %^  tx-update-card   tx-id
-          txn(status (sub status.txn 200))
-        [%noun (crip (noah !>(calldata.txn)))]
-      (tx-update-card tx-id txn action.u.this-tx)
+          tx(status (sub status.tx 200))
+        [%noun (crip (noah !>(calldata.tx)))]
+      (tx-update-card tx-id tx action.u.this-tx)
     ==
   [(zing cardss) transaction-store]
 ::

--- a/mar/wallet/update.hoon
+++ b/mar/wallet/update.hoon
@@ -29,7 +29,8 @@
     ::
         %tx-status
       %-  frond
-      (parse-transaction:parsing hash.upd txn.upd action.upd)
+      %^  parse-transaction:parsing  hash.upd
+      transaction.upd  action.upd
     ==
   --
 ++  grad  %noun

--- a/sur/zig/engine.hoon
+++ b/sur/zig/engine.hoon
@@ -31,7 +31,7 @@
       events=(list contract-event)
   ==
 ::
-::  contract events are converted to this -- `txn` is txn hash
+::  contract events are converted to this
 ::
 +$  contract-event  [contract=id:smart label=@tas =json]
 --

--- a/sur/zig/indexer.hoon
+++ b/sur/zig/indexer.hoon
@@ -5,10 +5,10 @@
 |%
 +$  query-type
   $?  %batch
-      %txn
+      %transaction
       %from
       %item
-      :: %item-txns
+      :: %item-transactions
       %holder
       %source
       %to
@@ -23,21 +23,21 @@
   $?  second-order-location
       town-location
       batch-location
-      txn-location
+      transaction-location
   ==
 +$  second-order-location  id:smart
 +$  town-location  id:smart
 +$  batch-location
   [town-id=id:smart batch-root=id:smart]
-+$  txn-location
-  [town-id=id:smart batch-root=id:smart txn-num=@ud]
++$  transaction-location
+  [town-id=id:smart batch-root=id:smart transaction-num=@ud]
 ::
 +$  location-index
   (map @ux (jar @ux location))
 +$  batch-index  ::  used for items
   (map @ux (jar @ux batch-location))
-+$  txn-index  ::  only ever one tx per id; -> (map (map))?
-  (map @ux (jar @ux txn-location))
++$  transaction-index  ::  only ever one tx per id; -> (map (map))?
+  (map @ux (jar @ux transaction-location))
 +$  second-order-index
   (map @ux (jar @ux second-order-location))
 ::
@@ -74,10 +74,10 @@
   ==
 ::
 +$  indices-0
-  $:  =txn-index
+  $:  =transaction-index
       from-index=second-order-index
       item-index=batch-index
-      :: item-txns-index=second-order-index
+      :: item-transactions-index=second-order-index
       holder-index=second-order-index
       source-index=second-order-index
       to-index=second-order-index
@@ -88,9 +88,9 @@
 ::
 +$  batch-update-value
   [timestamp=@da location=town-location =batch]
-+$  txn-update-value
++$  transaction-update-value
   $:  timestamp=@da
-      location=txn-location
+      location=transaction-location
       =transaction:smart
       =output:eng
   ==
@@ -102,44 +102,20 @@
   $%  [%path-does-not-exist ~]
       [%batch batches=(map batch-id=id:smart batch-update-value)]
       [%batch-order =batch-order]
-      [%txn txns=(map txn-id=id:smart txn-update-value)]
+      [%transaction transactions=(map transaction-id=id:smart transaction-update-value)]
       [%item items=(jar item-id=id:smart item-update-value)]
       $:  %hash
           batches=(map batch-id=id:smart batch-update-value)
-          txns=(map txn-id=id:smart txn-update-value)
+          transactions=(map transaction-id=id:smart transaction-update-value)
           items=(jar item-id=id:smart item-update-value)
       ==
       [%newest-batch batch-id=id:smart batch-update-value]
       [%newest-batch-order batch-id=id:smart]
-      [%newest-txn txn-id=id:smart txn-update-value]
+      [%newest-transaction transaction-id=id:smart transaction-update-value]
       [%newest-item item-id=id:smart item-update-value]
       ::  %newest-hash type is just %hash, since can have multiple
-      ::  txns/items, considering second-order indices
+      ::  transactions/items, considering second-order indices
   ==
-::
-::  TODO: change update interface to below
-:: +$  update
-::   $@  ~
-::   $%  [%path-does-not-exist ~]
-::       [%batches (map batch-id=id:smart [timestamp=@da location=town-location =batch])]
-::       [%batch-order =batch-order]
-::       [%txns (map txn-id=id:smart [timestamp=@da location=txn-location =transaction:smart])]
-::       [%items (jar item-id=id:smart [timestamp=@da location=batch-location =item:smart])]
-::       $:  %hashes
-::           batches=(map batch-id=id:smart [timestamp=@da location=town-location =batch])
-::           txns=(map txn-id=id:smart [timestamp=@da location=txn-location =transaction:smart])
-::           items=(jar item-id=id:smart [timestamp=@da location=batch-location =item:smart])
-::       ==
-::       [%batch batch-id=id:smart timestamp=@da location=town-location =batch]
-::       [%newest-batch-id batch-id=id:smart]  ::  keep?
-::       [%txn txn-id=id:smart timestamp=@da location=txn-location =transaction:smart]
-::       [%item item-id=id:smart timestamp=@da location=batch-location =item:smart]
-::       $:  %hash
-::           batch=[batch-id=id:smart timestamp=@da location=town-location =batch]
-::           txn=[txn-id=id:smart timestamp=@da location=txn-location =transaction:smart]
-::           item=[item-id=id:smart timestamp=@da location=batch-location =item:smart]
-::       ==
-::   ==
 ::
 +$  consume-batch-args
   $:  root=id:smart

--- a/sur/zig/indexer.hoon
+++ b/sur/zig/indexer.hoon
@@ -28,9 +28,9 @@
 +$  second-order-location  id:smart
 +$  town-location  id:smart
 +$  batch-location
-  [town-id=id:smart batch-root=id:smart]
+  [town-id=id:smart batch-id=id:smart]
 +$  transaction-location
-  [town-id=id:smart batch-root=id:smart transaction-num=@ud]
+  [town-id=id:smart batch-id=id:smart transaction-num=@ud]
 ::
 +$  location-index
   (map @ux (jar @ux location))
@@ -118,7 +118,7 @@
   ==
 ::
 +$  consume-batch-args
-  $:  root=id:smart
+  $:  batch-id=id:smart
       transactions=processed-txs:eng
       =town:seq
       timestamp=@da

--- a/sur/zig/sequencer.hoon
+++ b/sur/zig/sequencer.hoon
@@ -51,7 +51,7 @@
       [%clear-state ~]
       ::  transactions
       [%receive-assets assets=state]
-      [%receive txns=(set transaction:smart)]
+      [%receive txs=(set transaction:smart)]
       ::  batching
       [%trigger-batch ~]
       [%perform-batch eth-block-height=@ud]

--- a/sur/zig/uqbar.hoon
+++ b/sur/zig/uqbar.hoon
@@ -12,15 +12,15 @@
   ==
 ::
 +$  write
-  $%  [%submit txn=transaction:smart]
-      [%receipt txn-hash=@ux ship-sig=[p=@ux q=ship r=life] uqbar-sig=sig:smart]
+  $%  [%submit =transaction:smart]
+      [%receipt transaction-hash=@ux ship-sig=[p=@ux q=ship r=life] uqbar-sig=sig:smart]
   ==
 ::
 ::  updates
 ::
 +$  write-result
   $%  [%sent ~]
-      [%receipt txn-hash=@ux ship-sig=[p=@ux q=ship r=life] uqbar-sig=sig:smart]
+      [%receipt transaction-hash=@ux ship-sig=[p=@ux q=ship r=life] uqbar-sig=sig:smart]
       [%rejected =ship]
       [%executed result=errorcode:smart]
       [%nonce value=@ud]

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -20,13 +20,13 @@
 ::
 +$  transaction-store
   %+  map  address:smart
-  $:  sent=(map @ux [txn=transaction:smart action=supported-actions])
+  $:  sent=(map @ux [=transaction:smart action=supported-actions])
       received=(map @ux transaction:smart)
   ==
 ::
 +$  pending-store
   %+  map  address:smart
-  (map @ux [txn=transaction:smart action=supported-actions])
+  (map @ux [=transaction:smart action=supported-actions])
 ::
 +$  transaction-status-code
   $%  %100  ::  100: transaction pending in wallet
@@ -53,7 +53,7 @@
 +$  wallet-update
   $%  [%new-book tokens=(map pub=id:smart =book)]
       [%new-metadata metadata=metadata-store]
-      [%tx-status hash=@ux txn=transaction:smart action=supported-actions]
+      [%tx-status hash=@ux =transaction:smart action=supported-actions]
   ==
 ::
 ::  received from web interface


### PR DESCRIPTION
Get rid of `txn`: now mostly use `transaction`, with a few `tx` when shorter name required.

Get rid of `root` in `%indexer`. Now use `batch-id` everywhere user-facing, with a few `root` references when interfacing with other Uqbar apps that use that term.