### PR TITLE
Add app-upgrade thread to master

### DIFF
--- a/ted/upgrade.hoon
+++ b/ted/upgrade.hoon
@@ -1,0 +1,28 @@
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+::
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+;<  our=ship  bind:m  get-our:strandio
+~&  >  "Nuking all apps in {<our>}'s %zig to prepare for upgrade..."
+::
+=/  apps=(list @tas)
+  :~  %uqbar
+      %rollup
+      %sequencer
+      %indexer
+      %wallet
+      %ziggurat
+      %faucet
+      %batcher-interval
+      %batcher-threshold
+  ==
+=/  cards
+  %+  turn  apps
+  |=  name=@tas
+  [%pass /poke %agent [our %hood] %poke kiln-nuke+!>([name %|])]
+;<  ~  bind:m  (send-raw-cards:strandio `(list card:agent:gall)`cards)
+(pure:m !>('done.'))


### PR DESCRIPTION
This will be part of `release-0.0.5` in order to have users nuke their app states in order to download `next/smart`