### PR TITLE
Da/sig lib

### DIFF
--- a/con/lib/multisig.hoon
+++ b/con/lib/multisig.hoon
@@ -22,7 +22,7 @@
     $%  ::  called once to initialize multisig
         [%create threshold=@ud members=(pset address)]
         ::
-        [%execute multisig=id sigs=(pset sig) calls=(list [to=id town=id =calldata]) deadline=@ud]
+        [%execute multisig=id sigs=(pmap id sig) calls=(list [to=id town=id =calldata]) deadline=@ud]
         ::
         [%vote multisig=id proposal-hash=@ux aye=?]
         [%propose multisig=id calls=(list [to=id town=id =calldata])]
@@ -36,11 +36,10 @@
 ::
 ++  lib
   |%
-  ++  type-hash-execute
+  ++  execute-mold
     :: TODO  gas price
     ::       gas limit
     ::       refund receiver
-    %-  sham
     $:  multisig=id
         calls=(list [to=id town=id =calldata])
         nonce=@ud

--- a/con/multisig.hoon
+++ b/con/multisig.hoon
@@ -47,26 +47,22 @@
   ?-    -.act
       %execute
     ::  assert sigs aren't duplicated
-    ?>  ~(apt pn sigs.act)
+    ?>  ~(apt py sigs.act)
     ::  assert threshold has been met
-    ?>  (gte ~(wyt pn sigs.act) threshold.noun.multisig)
+    ?>  (gte ~(wyt py sigs.act) threshold.noun.multisig)
     ::  assert deadline is valid
     ?>  (lte eth-block.context deadline.act)
     ::  assert signatures are correct
-    =/  typed-message-hash=@ux
-      ^-  @
-      %^    sham  ::  XX use sham or shag? unclear - I'm using sham in fungible.hoon
-          (hash-data this.context this.context town.context 0)
-        type-hash-execute:lib
-      (sham [multisig.act calls.act (lent executed.noun.multisig) deadline.act])
-    ?>  %+  levy  ~(tap pn sigs.act)
-        |=  =sig
-        %-  ~(has in members.noun.multisig)
-        %-  address-from-pub
-        %-  serialize-point:secp256k1:secp:crypto
-        (ecdsa-raw-recover:secp256k1:secp:crypto typed-message-hash sig)
+    =/  =typed-message
+      :+  (hash-data this.context this.context town.context 0)
+        execute-mold:lib
+      [multisig.act calls.act (lent executed.noun.multisig) deadline.act]
+    ?>  %+  levy  ~(tap py sigs.act)
+        |=  [=id =sig]
+        (verify-ecdsa-signed typed-message sig id)
     ::  add to call history
-    =.  executed.noun.multisig  [typed-message-hash executed.noun.multisig]
+    =.  executed.noun.multisig
+      [`@ux`(sham typed-message) executed.noun.multisig]
     ::  create continuation calls
     :-  calls.act
     (result [%&^multisig]^~ ~ ~ ~)

--- a/lib/zig/sys/smart.hoon
+++ b/lib/zig/sys/smart.hoon
@@ -174,7 +174,15 @@
   ==
 ::
 ::  EIP-712 mold for offchain data signing
-+$  typed-message  [domain=id type-hash=@ message=@]
++$  typed-message  [domain=id type=mold message=*]
+::
+++  verify-ecdsa-signed
+  |=  [=typed-message =sig who=id]
+  ^-  ?
+  =-  =(who -)
+  %-  address-from-pub
+  %-  serialize-point:secp256k1:secp:crypto
+  (ecdsa-raw-recover:secp256k1:secp:crypto (sham typed-message) sig)
 ::
 ::  typed paths inside contracts
 ::  taken from: https://github.com/urbit/urbit/pull/5887


### PR DESCRIPTION
Was helping markus use signatures for contract dev and realized everything could be a lot easier
- changed the `+$typed-message` mold to make a lot more sense => `[domain=id type=mold message=*]`
- added a helper function `+verify-ecdsa-signed` to make sig-verification cleaner
- updated multisig and fungible to use these