### PR TITLE
indexer: become inert on kick

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -484,13 +484,15 @@
         [cards this]
       ::
           %kick
-        :_  this
-        %^    set-watch-target:ic
-            wire
-          [src.bowl %rollup]  ::  TODO: remove hardcode
-        ?:  ?=(%rollup-root-update -.wire)
-          rollup-root-path
-        rollup-capitol-path
+        ::  become inert on kick
+        `this
+        ::  :_  this
+        ::  %^    set-watch-target:ic
+        ::      wire
+        ::    [src.bowl %rollup]  ::  TODO: remove hardcode
+        ::  ?:  ?=(%rollup-root-update -.wire)
+        ::    rollup-root-path
+        ::  rollup-capitol-path
       ==
     ::
         [%sequencer-update ~]
@@ -502,11 +504,13 @@
         [cards this]
       ::
           %kick
-        :_  this
-        %^    set-watch-target:ic
-            sequencer-wire
-          [src.bowl %sequencer]  ::  TODO: remove hardcode
-        sequencer-path
+        ::  become inert on kick
+        `this
+        ::  :_  this
+        ::  %^    set-watch-target:ic
+        ::      sequencer-wire
+        ::    [src.bowl %sequencer]  ::  TODO: remove hardcode
+        ::  sequencer-path
       ==
     ::
         [%indexer-bootstrap-update ~]


### PR DESCRIPTION
@hosted-fornet: this change is designed to slot into release-0.0.5, in order to remove the issue of incompatible updates along subscription paths between the bacdun sequencer and people with the suite installed.

I've tested this on moons, and here's what seems to work for a smooth upgrade:

1. release-0.0.5 is sent out for OTA with this PR included
2. users install the OTA without issue
3. ~bacdun has all app states wiped and manually upgrades to release-0.0.6 (which will contain `next/smart`)
4. ~bacdun starts a fresh chain, turns on batching, faucet etc
5. release-0.0.6 is sent out for OTA

At any time after step 5, users can run this:
```
-zig!upgrade
|install ~dister-dozzod-bacdun %zig
```

This will nuke their 0.0.5 app states and begin install of 0.0.6, which will initially fail to install for users on 0.0.5. Once they install 0.0.6 successfully, their indexers will automatically re-subscribe to ~bacdun and go back to the resub-on-kick behavior.