### PR TITLE
engine: fix validation check for issued pacts

### DIFF
--- a/lib/zig/sys/engine.hoon
+++ b/lib/zig/sys/engine.hoon
@@ -290,9 +290,9 @@
             !(has:big p.chain id.p.item)
             ?:  ?=(%| -.item)
               .=  id
-              (hash-pact:smart source holder.p.item town.p.item code.p.item)
+              (hash-pact:smart [source holder town code]:p.item)
             .=  id
-            (hash-data:smart source holder.p.item town.p.item salt.p.item)
+            (hash-data:smart [source holder town salt]:p.item)
         ==
       ::
         %-  ~(all in burned.diff)


### PR DESCRIPTION
The line here was causing immutable contracts deployed through publish.hoon to fail validation. This was because we were checking the pact ID against the source, which was the ID of publish.hoon, but should be `0x0` in immutable contracts! Easy fix.