### PR TITLE
Add contract field to wallet's `asset-metadata`

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -562,8 +562,12 @@
     =/  pub  (slav %ux i.t.t.path)
     =/  our=(map @ux [transaction:smart supported-actions])
       (~(gut by pending-store) pub ~)
-    ::
     ``noun+!>(`(map @ux [transaction:smart supported-actions])`our)
+  ::
+      [%metadata @ ~]
+    ::  return (unit) specific metadata from our store
+    =/  found  (~(get by metadata-store) (slav %ux i.t.t.path))
+    ``noun+!>(`(unit asset-metadata)`found)
   ==
 ::
 ++  on-leave  on-leave:def

--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -149,8 +149,8 @@
     ~
   ?.  ?=(%& -.u.g)  ~
   ?+  token-type  ~
-    %token  `[%token town ;;(token-metadata noun.p.u.g)]
-    %nft    `[%nft town ;;(nft-metadata noun.p.u.g)]
+    %token  `[%token town source.p.u.g ;;(token-metadata noun.p.u.g)]
+    %nft    `[%nft town source.p.u.g ;;(nft-metadata noun.p.u.g)]
   ==
 ::
 ::  JSON parsing utils

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -15,8 +15,8 @@
 ::
 +$  metadata-store  (map id:smart asset-metadata)
 +$  asset-metadata
-  $%  [%token town=@ux token-metadata]
-      [%nft town=@ux nft-metadata]
+  $%  [%token town=@ux contract=id:smart token-metadata]
+      [%nft town=@ux contract=id:smart nft-metadata]
   ==
 ::
 +$  unfinished-transaction-store


### PR DESCRIPTION
While building pokur, realized that wallet needs to provide this information to other apps somehow. I also added a scry path where apps can get token metadata so they can use it to create transactions.