### PR TITLE
indexer: make subscriptions resub on kick again, upgrade: make thread inert

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -435,15 +435,13 @@
         [cards this]
       ::
           %kick
-        ::  become inert on kick
-        `this
-        ::  :_  this
-        ::  %^    set-watch-target:ic
-        ::      wire
-        ::    [src.bowl %rollup]  ::  TODO: remove hardcode
-        ::  ?:  ?=(%rollup-root-update -.wire)
-        ::    rollup-root-path
-        ::  rollup-capitol-path
+        :_  this
+        %^    set-watch-target:ic
+            wire
+          [src.bowl %rollup]  ::  TODO: remove hardcode
+        ?:  ?=(%rollup-root-update -.wire)
+          rollup-root-path
+        rollup-capitol-path
       ==
     ::
         [%sequencer-update ~]
@@ -455,13 +453,11 @@
         [cards this]
       ::
           %kick
-        ::  become inert on kick
-        `this
-        ::  :_  this
-        ::  %^    set-watch-target:ic
-        ::      sequencer-wire
-        ::    [src.bowl %sequencer]  ::  TODO: remove hardcode
-        ::  sequencer-path
+        :_  this
+        %^    set-watch-target:ic
+            sequencer-wire
+          [src.bowl %sequencer]  ::  TODO: remove hardcode
+        sequencer-path
       ==
     ::
         [%indexer-bootstrap-update ~]

--- a/ted/upgrade.hoon
+++ b/ted/upgrade.hoon
@@ -7,22 +7,26 @@
 =/  m  (strand ,vase)
 ^-  form:m
 ;<  our=ship  bind:m  get-our:strandio
-~&  >  "Nuking all apps in {<our>}'s %zig to prepare for upgrade..."
 ::
-=/  apps=(list @tas)
-  :~  %uqbar
-      %rollup
-      %sequencer
-      %indexer
-      %wallet
-      %ziggurat
-      %faucet
-      %batcher-interval
-      %batcher-threshold
-  ==
-=/  cards
-  %+  turn  apps
-  |=  name=@tas
-  [%pass /poke %agent [our %hood] %poke kiln-nuke+!>([name %|])]
-;<  ~  bind:m  (send-raw-cards:strandio `(list card:agent:gall)`cards)
-(pure:m !>('done.'))
+::  no state upgrades needed now, but keeping thread in case future states
+::  need to be reset.
+::
+::  ~&  >  "Nuking all apps in {<our>}'s %zig to prepare for upgrade..."
+::  ::
+::  =/  apps=(list @tas)
+::    :~  %uqbar
+::        %rollup
+::        %sequencer
+::        %indexer
+::        %wallet
+::        %ziggurat
+::        %faucet
+::        %batcher-interval
+::        %batcher-threshold
+::    ==
+::  =/  cards
+::    %+  turn  apps
+::    |=  name=@tas
+::    [%pass /poke %agent [our %hood] %poke kiln-nuke+!>([name %|])]
+::  ;<  ~  bind:m  (send-raw-cards:strandio `(list card:agent:gall)`cards)
+(pure:m !>('no upgrade necessary right now!'))


### PR DESCRIPTION
For `release-0.0.6`: %indexer should return to resubbing on kick, and upgrade thread is no longer needed. Don't want people accidentally nuking all their app states, so we will make the thread inert until a future time when it may be needed again.