### PR TITLE
indexer: fill in bunted time with `now.bowl`

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -594,6 +594,9 @@
           %new-peer-root
         =*  town-id   town.update
         =*  batch-id  root.update
+        =/  timestamp=@da
+          ?:  =(*@da timestamp.update)  now.bowl
+          timestamp.update
         ?:  (has-batch-id-already town-id batch-id)  `state
         =/  sequencer-update
           ^-  (unit [transactions=processed-txs:eng =town:seq])
@@ -609,7 +612,7 @@
             %+  %~  put  by
                 %+  ~(gut by town-update-queue)  town-id
                 *(map batch-id=@ux timestamp=@da)
-            batch-id  timestamp.update
+            batch-id  timestamp
           ==
         :_  state
         :_  ~
@@ -619,7 +622,7 @@
         :*  batch-id
             transactions.u.sequencer-update
             town.u.sequencer-update
-            timestamp.update
+            timestamp
             %.y
         ==
       ==


### PR DESCRIPTION
If we get a bunted timestamp, fill it in with `now.bowl`. This means that different users' %indexers may disagree on block timestamps.

The bunted times are coming from [here](https://github.com/uqbar-dao/uqbar-core/blob/master/app/rollup.hoon#L58). If we want a similar behavior to this PR, we could have the %rollup assign its `now.bowl` rather than sending a bunted value.

Alternatively, to increase canonicity of block timestamps, we could store in state of %rollup a `most-recent-batch-times=(map town-id=@ux most-recent-timestamp=@da)`. Then, `+on-watch`, we would hand back
```hoon
[%sequencer-rollup-update !>(`town-update`[%new-peer-root id (rear roots.hall) (~(gut by most-recent-batch-times) id *@da)])]
```

This would involve a change in state, so perhaps we should queue this up on `next/smart`.