### PR TITLE
wallet: add ephemeral nonces to pending txns

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -315,7 +315,10 @@
       ::  take in a new pending transaction
       =/  =caller:smart
         :+  from.act
-          0  ::  we fill in *correct* nonce upon submission
+          ::  this is an ephemeral nonce used to differentiate between
+          ::  pending transactions. the real on-chain nonce is assigned
+          ::  upon signing.
+          ~(wyt by pending-store)
         ::  generate our zigs token account ID
         (hash-data:smart zigs-contract-id:smart from.act town.act `@`'zigs')
       ::  build calldata of transaction, depending on argument type

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -318,7 +318,7 @@
           ::  this is an ephemeral nonce used to differentiate between
           ::  pending transactions. the real on-chain nonce is assigned
           ::  upon signing.
-          ~(wyt by pending-store)
+          `@ud`(cut 3 [0 3] eny.bowl)
         ::  generate our zigs token account ID
         (hash-data:smart zigs-contract-id:smart from.act town.act `@`'zigs')
       ::  build calldata of transaction, depending on argument type


### PR DESCRIPTION
Tested, working, no change to anything except wallet pending txns now have nonces equivalent to the size of the pending map. ~~This does have the potential for overlapping txn hashes, in a situation where two identical transactions are entered one after another, but with a third txn being signed and submitted between their entries. ~~

Edit: made better by just using `eny.bowl`