### PR TITLE
Wallet: provide responses to apps that build transactions and send through us

### DIFF
--- a/app/faucet.hoon
+++ b/app/faucet.hoon
@@ -88,6 +88,7 @@
           :-  %wallet-poke
           !>  ^-  wallet-poke:w
           :*  %transaction
+              origin=~  ::  we don't care to be notified
               from=address.u.town-info
               contract=zigs-contract.u.town-info
               town=town-id.action

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -447,18 +447,23 @@
       ~&  >>>  "%wallet: couldn't find transaction hash for update!"
       $(unfinished t.unfinished, still-looking [i.unfinished still-looking])
     ::  put latest version of tx into transaction-store
-    =/  updated
+    =/  updated=[@ux =origin transaction:smart supported-actions output:eng]
       =+  found=(~(got by transactions.tx-latest) hash.i.unfinished)
       ::  add 200 to finished status code to get wallet status equivalent
       =.  status.transaction.found  (add 200 status.transaction.found)
-      [hash.i.unfinished origin.i.unfinished transaction.found action.i.unfinished output.found]
+      :*  hash.i.unfinished
+          origin.i.unfinished
+          transaction.found
+          action.i.unfinished
+          output.found
+      ==
     ::  when we have a finished transaction, use transaction origin to
     ::  notify an app about their completed transaction.
     %=  $
       unfinished  t.unfinished
         cards
       :-  (finished-tx-update-card updated)
-      ?~  -.+.updated  cards
+      ?~  origin.updated  cards
       [(notify-origin-card our.bowl updated) cards]
         transaction-store
       %+  ~(jab by transaction-store)  address.caller.tx.i.unfinished

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -239,7 +239,9 @@
             (~(put by pending-store) from.act (~(del by my-pending) hash.act))
           ::
               unfinished-transaction-store
-            [[hash tx action.u.found] unfinished-transaction-store]
+            %+  ~(put by unfinished-transaction-store)
+              hash
+            [origin.u.found tx action.u.found]
           ::
               nonces
             (~(put by nonces) from.act (~(put by our-nonces) town.tx +(nonce)))
@@ -286,7 +288,9 @@
             (~(put by pending-store) from.act (~(del by my-pending) hash.act))
           ::
               unfinished-transaction-store
-            [[hash tx action.u.found] unfinished-transaction-store]
+            %+  ~(put by unfinished-transaction-store)
+              hash
+            [origin.u.found tx action.u.found]
           ::
               nonces
             (~(put by nonces) from.act (~(put by our-nonces) town.tx +(nonce)))
@@ -371,9 +375,10 @@
       =/  =transaction:smart  [[0 0 0] calldata shell]
       ~&  >>  "%wallet: transaction pending with hash {<hash>}"
       ::  add to our pending-store with empty signature
+      ::  define origin as source desk + their wire
       =/  my-pending
         %+  ~(put by (~(gut by pending-store) from.act ~))
-        hash  [transaction action.act]
+        hash  [`[q.byk.bowl wire.act] transaction action.act]
       :-  (tx-update-card hash transaction action.act)^~
       %=  state
         pending-store  (~(put by pending-store) from.act my-pending)
@@ -400,14 +405,15 @@
     ::  update status, then insert in tx-store mapping
     ::  and build an update card with its new status.
     =|  cards=(list card)
-    =|  still-looking=(list [hash=@ux tx=transaction:smart action=supported-actions])
-    =*  unfinished  unfinished-transaction-store
+    =|  still-looking=(list [hash=@ux =origin tx=transaction:smart action=supported-actions])
+    =/  unfinished=(list [hash=@ux =origin tx=transaction:smart action=supported-actions])
+      ~(tap by unfinished-transaction-store)
     |-
     ?~  unfinished
       :_  %=  this
             tokens  new-tokens
             metadata-store  new-metadata
-            unfinished-transaction-store  still-looking
+            unfinished-transaction-store  (malt still-looking)
           ==
       :+  [%give %fact ~[/book-updates] %wallet-frontend-update !>(`wallet-frontend-update`[%new-book new-tokens])]
         [%give %fact ~[/metadata-updates] %wallet-frontend-update !>(`wallet-frontend-update`[%new-metadata new-metadata])]
@@ -418,24 +424,28 @@
           %+  weld  /(scot %p our.bowl)/uqbar/(scot %da now.bowl)
           /indexer/transaction/(scot %ux hash.i.unfinished)/noun
       ==
-    ::  this is unpleasant
     ?.  ?&  ?=(^ tx-latest)
             ?=(%transaction -.tx-latest)
         ==
-      ~&  >>  "%wallet: couldn't find transaction hash for update(3)"
+      ~&  >>>  "%wallet: couldn't find transaction hash for update!"
       $(unfinished t.unfinished, still-looking [i.unfinished still-looking])
     ::  put latest version of tx into transaction-store
     =/  updated
       =+  found=(~(got by transactions.tx-latest) hash.i.unfinished)
       ::  add 200 to finished status code to get wallet status equivalent
       =.  status.transaction.found  (add 200 status.transaction.found)
-      [hash.i.unfinished transaction.found action.i.unfinished output.found]
+      [hash.i.unfinished origin.i.unfinished transaction.found action.i.unfinished output.found]
+    ::  when we have a finished transaction, use transaction origin to
+    ::  notify an app about their completed transaction.
     %=  $
       unfinished  t.unfinished
-      cards       [(finished-tx-update-card updated) cards]
+        cards
+      :-  (finished-tx-update-card updated)
+      ?~  -.+.updated  cards
+      [(notify-origin-card our.bowl updated) cards]
         transaction-store
       %+  ~(jab by transaction-store)  address.caller.tx.i.unfinished
-      |=  m=(map @ux [transaction:smart supported-actions output:eng])
+      |=  m=(map @ux [origin transaction:smart supported-actions output:eng])
       (~(put by m) updated)
     ==
   ::
@@ -534,18 +544,18 @@
     =/  pending  (~(gut by pending-store) address ~)
     ?^  f2=(~(get by pending) tx-hash)
       [%unfinished-transaction u.f2]
-    ?~  f3=(find [tx-hash]~ (turn unfinished-transaction-store head))
-      ~
-    [%unfinished-transaction +:(snag u.f3 unfinished-transaction-store)]
+    ?^  f3=(~(get by unfinished-transaction-store) tx-hash)
+      [%unfinished-transaction u.f3]
+    ~
   ::
   ::  internal / non-standard noun scries
   ::
       [%pending-store @ ~]
     ::  return pending store for given pubkey, noun format
     =/  pub  (slav %ux i.t.t.path)
-    =/  our=(map @ux [transaction:smart supported-actions])
+    =/  our=(map @ux [origin transaction:smart supported-actions])
       (~(gut by pending-store) pub ~)
-    ``noun+!>(`(map @ux [transaction:smart supported-actions])`our)
+    ``noun+!>(`(map @ux [origin transaction:smart supported-actions])`our)
   ::
   ::  JSON scries, for frontend
   ::
@@ -600,12 +610,12 @@
     %-  pairs:enjs
     :~  :-  'unfinished'
         %-  pairs:enjs
-        %+  turn  unfinished-transaction-store.state
+        %+  turn  ~(tap by unfinished-transaction-store.state)
         transaction-no-output:parsing
         :-  'finished'
         %-  pairs:enjs
         %+  turn  ~(tap by transaction-store.state)
-        |=  [a=@ux m=(map @ux [transaction:smart supported-actions output:eng])]
+        |=  [a=@ux m=(map @ux [origin transaction:smart supported-actions output:eng])]
         :-  (scot %ux a)
         %-  pairs:enjs
         (turn ~(tap by m) transaction-with-output:parsing)
@@ -614,7 +624,7 @@
       [%pending @ ~]
     ::  return pending store for given pubkey
     =/  pub  (slav %ux i.t.t.path)
-    =/  our=(map @ux [transaction:smart supported-actions])
+    =/  our=(map @ux [origin transaction:smart supported-actions])
       (~(gut by pending-store) pub ~)
     ::
     =;  =json  ``json+!>(json)

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -378,7 +378,7 @@
       ::  define origin as source desk + their wire
       =/  my-pending
         %+  ~(put by (~(gut by pending-store) from.act ~))
-        hash  [`[q.byk.bowl wire.act] transaction action.act]
+        hash  [origin.act transaction action.act]
       :-  (tx-update-card hash transaction action.act)^~
       %=  state
         pending-store  (~(put by pending-store) from.act my-pending)

--- a/lib/zig/sys/engine.hoon
+++ b/lib/zig/sys/engine.hoon
@@ -79,6 +79,7 @@
         ~&  >>>  "engine: tx failed gas audit"
         (exhaust bud.gas.tx %3 ~)
       ::
+      =/  gas-payer  address.caller.tx
       |-  ::  recursion point for calls
       ::
       ?:  &(=(0x0 contract.tx) =(%burn p.calldata.tx))
@@ -97,6 +98,9 @@
           ?&  =(contract.tx zigs-contract-id:smart)
               =(p.calldata.tx %give)
           ==
+        ::  only assert budget check when gas-payer is interacting
+        ?.  =(address.caller.tx gas-payer)
+          [0 q.calldata.tx]
         [bud.gas.tx q.calldata.tx]
       ?~  pac=(get:big p.chain contract.tx)
         ~&  >>>  "engine: call to missing pact"

--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -18,7 +18,7 @@
 ++  finished-tx-update-card
   |=  in=[@ux origin transaction:smart supported-actions output:eng]
   ^-  card
-  =+  `wallet-frontend-update`[%finished-tx [-.in +.+.in]]
+  =+  `wallet-frontend-update`[%finished-tx in]
   [%give %fact ~[/tx-updates] %wallet-frontend-update !>(-)]
 ::
 ++  notify-origin-card

--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -16,14 +16,25 @@
   [%give %fact ~[/tx-updates] %wallet-frontend-update !>(-)]
 ::
 ++  finished-tx-update-card
-  |=  in=[@ux transaction:smart supported-actions output:eng]
+  |=  in=[@ux origin transaction:smart supported-actions output:eng]
   ^-  card
-  =+  `wallet-frontend-update`[%finished-tx in]
+  =+  `wallet-frontend-update`[%finished-tx [-.in +.+.in]]
   [%give %fact ~[/tx-updates] %wallet-frontend-update !>(-)]
+::
+++  notify-origin-card
+  |=  [our=@p in=[@ux =origin transaction:smart supported-actions output:eng]]
+  ^-  card
+  ?~  origin.in  !!
+  :*  %pass  q.u.origin.in
+      %agent  [our p.u.origin.in]
+      %poke  %wallet-update
+      !>  ^-  wallet-update
+      [%finished-transaction +.in]
+  ==
 ::
 ++  get-sent-history
   |=  [=address:smart newest=? our=@p now=@da]
-  ^-  (map @ux [transaction:smart supported-actions output:eng])
+  ^-  (map @ux [origin transaction:smart supported-actions output:eng])
   =/  transaction-history=update:ui
     .^  update:ui
         %gx
@@ -35,7 +46,8 @@
   ?.  ?=(%transaction -.transaction-history)  ~
   %-  ~(urn by transactions.transaction-history)
   |=  [hash=@ux @ * =transaction:smart =output:eng]
-  :+  transaction(status (add 200 `@`status.transaction))
+  :^    ~
+      transaction(status (add 200 `@`status.transaction))
     [%noun calldata.transaction]
   output
 ::
@@ -238,7 +250,7 @@
     |=([prop=@tas val=@t] [prop [%s val]])
   ::
   ++  transaction-with-output
-    |=  [hash=@ux t=transaction:smart action=supported-actions o=output:eng]
+    |=  [hash=@ux =origin t=transaction:smart action=supported-actions o=output:eng]
     :-  (scot %ux hash)
     %-  pairs
     :~  ['transaction' (transaction hash t action)]
@@ -246,7 +258,7 @@
     ==
   ::
   ++  transaction-no-output
-    |=  [hash=@ux t=transaction:smart action=supported-actions]
+    |=  [hash=@ux =origin t=transaction:smart action=supported-actions]
     :-  (scot %ux hash)
     (transaction hash t action)
   ::

--- a/mar/wallet/frontend-update.hoon
+++ b/mar/wallet/frontend-update.hoon
@@ -29,11 +29,11 @@
     ::
         %tx-status
       %-  frond
-      (transaction-no-output:parsing +.upd)
+      (transaction-no-output:parsing hash.upd ~ +.+.upd)
     ::
         %finished-tx
       %-  frond
-      (transaction-with-output:parsing +.upd)
+      (transaction-with-output:parsing hash.upd ~ +.+.upd)
     ==
   --
 ++  grad  %noun

--- a/mar/wallet/frontend-update.hoon
+++ b/mar/wallet/frontend-update.hoon
@@ -33,7 +33,7 @@
     ::
         %finished-tx
       %-  frond
-      (transaction-with-output:parsing hash.upd ~ +.+.upd)
+      (transaction-with-output:parsing +.upd)
     ==
   --
 ++  grad  %noun

--- a/mar/wallet/poke.hoon
+++ b/mar/wallet/poke.hoon
@@ -9,7 +9,9 @@
     ^-  wallet-poke
     %-  wallet-poke
     |^
-    (process jon)
+    =/  procd  (process jon)
+    ?.  ?=(%transaction -.procd)  procd
+    [%transaction origin=~ +.procd]
     ++  process
       %-  of
       :~  [%import-seed (ot ~[[%mnemonic so] [%password so] [%nick so]])]

--- a/readme.md
+++ b/readme.md
@@ -107,13 +107,13 @@ First, create a pending transaction.
 The `%wallet` will send the transaction hash on a subscription wire as well as print it in the Dojo.
 ```hoon
 ::  Send zigs tokens.
-:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=123.456 item=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6]]
+:uqbar &wallet-poke [%transaction ~ from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=123.456 item=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6]]
 
 ::  Send an NFT.
-:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0xb526.8432.294e.1c99.de7f.0cd9.2634.332a.28d3.9b76.4549.b51f.0fb2.80d5.91f1.1f5a town=0x0 action=[%give-nft to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de item=0xf4db.64cc.9ab5.5d34.8aa5.be1c.1de2.a6c3.10f8.f18a.a6f0.4f17.6051.e8e3.5bac.ce63]]
+:uqbar &wallet-poke [%transaction ~ from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0xb526.8432.294e.1c99.de7f.0cd9.2634.332a.28d3.9b76.4549.b51f.0fb2.80d5.91f1.1f5a town=0x0 action=[%give-nft to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de item=0xf4db.64cc.9ab5.5d34.8aa5.be1c.1de2.a6c3.10f8.f18a.a6f0.4f17.6051.e8e3.5bac.ce63]]
 
 ::  Use the custom transaction interface to send zigs tokens.
-:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%noun [%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=69.000 from-account=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6 to-account=`0xd79b.98fc.7d3b.d71b.4ac9.9135.ffba.cc6c.6c98.9d3b.8aca.92f8.b07e.a0a5.3d8f.a26c]]]
+:uqbar &wallet-poke [%transaction ~ from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%noun [%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=69.000 from-account=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6 to-account=`0xd79b.98fc.7d3b.d71b.4ac9.9135.ffba.cc6c.6c98.9d3b.8aca.92f8.b07e.a0a5.3d8f.a26c]]]
 ```
 
 Then, sign the transaction and assign it a gas budget.
@@ -308,7 +308,7 @@ To deploy on town `0x0`, in the Dojo:
 =contract-path /=zig=/con/compiled/multisig/jam
 =contract-jam .^(@ %cx contract-path)
 =contract [- +]:(cue contract-jam)
-:uqbar &wallet-poke [%transaction from=[youraddress] contract=0x1111.1111 town=0x0 action=[%noun [%deploy mutable=%.n cont=contract interface=~ types=~]]]
+:uqbar &wallet-poke [%transaction ~ from=[youraddress] contract=0x1111.1111 town=0x0 action=[%noun [%deploy mutable=%.n cont=contract interface=~ types=~]]]
 ```
 
 

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -107,6 +107,8 @@
       [%add-tracked-address address=@ux nick=@t]
       ::  testing and internal
       [%set-nonce address=@ux town=@ux new=@ud]
+      [%approve-origin (pair term wire) gas=[rate=@ud bud=@ud]]
+      [%remove-origin (pair term wire)]
       ::
       ::  TX submit pokes
       ::

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -3,7 +3,7 @@
 |%
 +$  signature   [p=@ux q=ship r=life]
 ::  for app-generated transactions to be notified of their txn results
-+$  origin  (unit (pair desk wire))
++$  origin  (unit (pair term wire))
 ::
 ::  book: the primary map of assets that we track
 ::  supports fungibles and NFTs
@@ -131,7 +131,7 @@
       ==
       ::
       $:  %transaction
-          =wire
+          =origin
           from=address:smart
           contract=id:smart
           town=@ux

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -2,6 +2,8 @@
 /+  smart=zig-sys-smart
 |%
 +$  signature   [p=@ux q=ship r=life]
+::  for app-generated transactions to be notified of their txn results
++$  origin  (unit (pair desk wire))
 ::
 ::  book: the primary map of assets that we track
 ::  supports fungibles and NFTs
@@ -25,17 +27,17 @@
   (map @ux [=typed-message:smart =sig:smart])
 ::
 +$  unfinished-transaction-store
-  (list [hash=@ux tx=transaction:smart action=supported-actions])
+  (map @ux [=origin =transaction:smart action=supported-actions])
 ::
 ::  inner maps keyed by transaction hash
 ::
 +$  transaction-store
   %+  map  address:smart
-  (map @ux [=transaction:smart action=supported-actions =output:eng])
+  (map @ux [=origin =transaction:smart action=supported-actions =output:eng])
 ::
 +$  pending-store
   %+  map  address:smart
-  (map @ux [=transaction:smart action=supported-actions])
+  (map @ux [=origin =transaction:smart action=supported-actions])
 ::
 +$  transaction-status-code
   $?  %100  ::  100: transaction pending in wallet
@@ -67,10 +69,12 @@
       [%addresses saved=(set address:smart)]
       [%signed-message =typed-message:smart =sig:smart]
       $:  %unfinished-transaction
+          =origin
           =transaction:smart
           action=supported-actions
       ==
       $:  %finished-transaction
+          =origin
           =transaction:smart
           action=supported-actions
           =output:eng
@@ -127,6 +131,7 @@
       ==
       ::
       $:  %transaction
+          =wire
           from=address:smart
           contract=id:smart
           town=@ux

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -89,6 +89,7 @@
       [%tx-status hash=@ux =transaction:smart action=supported-actions]
       $:  %finished-tx
           hash=@ux
+          =origin
           =transaction:smart
           action=supported-actions
           =output:eng


### PR DESCRIPTION
The purpose of this PR is to add a scheme to the wallet agent where apps can be notified of completed transactions that they initiated. I'm actively using it in %pokur where this behavior is very necessary.

I considered routing these pokes through %uqbar but it actually doesn't make a difference because the receiving app does not yet have a way in gall to distinguish the "source app". So it just doesn't matter and I'll keep them going straight from %wallet. If this changes in the future will app sandboxing we can update then.

This is a breaking change to %wallet agent state so it's going to `next/smart`