### PR TITLE
Engine bugfix: don't enforce budget on zigs transactions that are part of continuation calls

### DIFF
--- a/lib/zig/sys/engine.hoon
+++ b/lib/zig/sys/engine.hoon
@@ -79,6 +79,7 @@
         ~&  >>>  "engine: tx failed gas audit"
         (exhaust bud.gas.tx %3 ~)
       ::
+      =/  gas-payer  address.caller.tx
       |-  ::  recursion point for calls
       ::
       ?:  &(=(0x0 contract.tx) =(%burn p.calldata.tx))
@@ -97,6 +98,9 @@
           ?&  =(contract.tx zigs-contract-id:smart)
               =(p.calldata.tx %give)
           ==
+        ::  only assert budget check when gas-payer is interacting
+        ?.  =(address.caller.tx gas-payer)
+          [0 q.calldata.tx]
         [bud.gas.tx q.calldata.tx]
       ?~  pac=(get:big p.chain contract.tx)
         ~&  >>>  "engine: call to missing pact"


### PR DESCRIPTION
This came up when performing a zigs %give from a contract inside a continuation call. Since the initial transaction caller pays the budget for all continuation calls, the budget should not be a part of the zigs token transfer validation in the contract. To nullify that line of logic in the contract, we can just set the field to 0 in the engine.

In the future I want to remove the budget field from zigs contract entirely if possible, and do all this logic in the engine.