### PR TITLE
ziggurat: re-add `%add-test` with `test-steps`

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -137,6 +137,13 @@
     ^-  [[(list card) test] _state]
     =/  =project  (~(got by projects) project-name)
     =/  addresses=^vase  !>(virtualnet-addresses)
+    =.  surs
+      ?~  zig-val=(~(get by surs) %zig)
+        (~(put by surs) %zig /sur/zig/ziggurat)
+      ?:  =(/sur/zig/ziggurat u.zig-val)  surs
+      ~|("%ziggurat: %zig face reserved for /sur/zig/ziggurat; got {<u.zig-val>}" !!)
+    ?.  =(1 (lent (fand ~[/sur/zig/ziggurat] ~(val by surs))))
+      ~|("%ziggurat: please use only %zig face for /sur/zig/ziggurat; got {<surs>}" !!)
     =^  subject=(each ^vase @t)  state
       (compile-test-surs `@tas`project-name ~(tap by surs))
     =/  =test
@@ -548,6 +555,15 @@
         %add-and-queue-test
       %-  add-and-queue-test
       [project name test-surs test-steps]:act
+    ::
+        %save-test-to-file
+      =/  =project  (~(got by projects) project.act)
+      =/  =test  (~(got by tests.project) id.act)
+      =/  file-text=@t  (make-test-steps-file test)
+      =.  test-steps-file.test  path.act
+      =.  tests.project  (~(put by tests.project) id.act test)
+      :-  (make-save-file project.act path.act file-text)^~
+      state(projects (~(put by projects) project.act project))
     ::
         %add-test-file
       =/  =project  (~(got by projects) project.act)

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -133,6 +133,49 @@
   :^  [our %ziggurat]  %poke  %ziggurat-action
   !>([project %run-queue ~])
 ::
+++  make-test-steps-file
+  |=  =test
+  ^-  @t
+  %+  rap  3
+  :~
+  ::  imports
+    %+  roll  ~(tap by test-surs.test)
+    |=  [[face=@tas file=path] imports=@t]
+    %+  rap  3
+    :~  imports
+        '/=  '
+        face
+        '  '
+        (crip (noah !>(file)))
+        '\0a'
+    ==
+  ::  infix
+    '''
+    ::
+    |%
+    ++  $
+      ^-  test-steps:zig
+      :~
+
+    '''
+  ::  test-steps
+    %+  roll  steps.test
+    |=  [=test-step test-steps-text=@t]
+    %+  rap  3
+    :~  test-steps-text
+        '  ::\0a'
+        '    '
+        (crip (noah !>(test-step)))
+        '\0a'
+    ==
+  ::  suffix
+    '''
+      ==
+    --
+
+    '''
+  ==
+::
 ++  text-to-zebra-noun
   |=  [tex=@t smart-lib=vase]
   ^-  *

--- a/mar/ziggurat/action.hoon
+++ b/mar/ziggurat/action.hoon
@@ -32,13 +32,18 @@
           [%read-desk ul]
       ::
           [%add-test parse-add-test]
+          [%add-and-run-test parse-add-test]
+          [%add-and-queue-test parse-add-test]
+      ::
+          [%add-test-file parse-add-test-file]
+          [%add-and-run-test-file parse-add-test-file]
+          [%add-and-queue-test-file parse-add-test-file]
+      ::
           [%delete-test (ot ~[[%id (se %ux)]])]
           [%run-test (ot ~[[%id (se %ux)]])]
-          [%add-and-run-test parse-add-test]
           [%run-queue ul]
           [%clear-queue ul]
           [%queue-test (ot ~[[%id (se %ux)]])]
-          [%add-and-queue-test parse-add-test]
       ::
           [%add-custom-step parse-add-custom-step]
           [%delete-custom-step (ot ~[[%test-id (se %ux)] [%tag (se %tas)]])]
@@ -103,6 +108,13 @@
       ==
     ::
     ++  parse-add-test
+      %-  ot
+      :^    [%name so:dejs-soft:format]
+          [%test-surs (ar pa)]
+        [%test-steps (ar parse-test-step)]
+      ~
+    ::
+    ++  parse-add-test-file
       %-  ot
       :+  [%name so:dejs-soft:format]
         [%path pa]

--- a/mar/ziggurat/action.hoon
+++ b/mar/ziggurat/action.hoon
@@ -34,6 +34,7 @@
           [%add-test parse-add-test]
           [%add-and-run-test parse-add-test]
           [%add-and-queue-test parse-add-test]
+          [%save-test-to-file (ot ~[[%id (se %ux)] [%path pa]])]
       ::
           [%add-test-file parse-add-test-file]
           [%add-and-run-test-file parse-add-test-file]

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -133,22 +133,22 @@
           [%run-queue ~]  ::  can be used as [%$ %run-queue ~]
           [%clear-queue ~]
           [%queue-test id=@ux]
-          ::
+      ::
           [%add-custom-step test-id=@ux tag=@tas =path]
           [%delete-custom-step test-id=@ux tag=@tas]
-          ::
+      ::
           [%add-app-to-dashboard app=@tas sur=path mold-name=@t mar=path]
           [%delete-app-from-dashboard app=@tas]
-          ::
+      ::
           [%add-town-sequencer town-id=@ux who=@p]
           [%delete-town-sequencer town-id=@ux]
-          ::
+      ::
           [%stop-pyro-ships ~]
           [%start-pyro-ships ships=(list @p)]  ::  ships=~ -> [~nec ~bud]
           [%start-pyro-snap snap=path]
       ::
           [%publish-app title=@t info=@t color=@ux image=@t version=[@ud @ud @ud] website=@t license=@t]
-          ::
+      ::
           [%add-user-file file=path]
           [%delete-user-file file=path]
       ==

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -119,14 +119,19 @@
           [%compile-contract =path]  ::  path of form /[desk]/path/to/contract, e.g., /zig/con/fungible/hoon
           [%read-desk ~]  ::  make-project-update, make-watch-for-file-changes
       ::
-          [%add-test name=(unit @t) =path]  ::  name optional
+          [%add-test name=(unit @t) =test-surs =test-steps]  ::  name optional
+          [%add-and-run-test name=(unit @t) =test-surs =test-steps]
+          [%add-and-queue-test name=(unit @t) =test-surs =test-steps]
+      ::
+          [%add-test-file name=(unit @t) =path]  ::  name optional
+          [%add-and-run-test-file name=(unit @t) =path]
+          [%add-and-queue-test-file name=(unit @t) =path]
+      ::
           [%delete-test id=@ux]
           [%run-test id=@ux]
-          [%add-and-run-test name=(unit @t) =path]
           [%run-queue ~]  ::  can be used as [%$ %run-queue ~]
           [%clear-queue ~]
           [%queue-test id=@ux]
-          [%add-and-queue-test name=(unit @t) =path]
           ::
           [%add-custom-step test-id=@ux tag=@tas =path]
           [%delete-custom-step test-id=@ux tag=@tas]

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -122,6 +122,7 @@
           [%add-test name=(unit @t) =test-surs =test-steps]  ::  name optional
           [%add-and-run-test name=(unit @t) =test-surs =test-steps]
           [%add-and-queue-test name=(unit @t) =test-surs =test-steps]
+          [%save-test-to-file id=@ux =path]
       ::
           [%add-test-file name=(unit @t) =path]  ::  name optional
           [%add-and-run-test-file name=(unit @t) =path]


### PR DESCRIPTION
for use with frontend.

expectation is more developed tests can be imported from files using what has been retitled `%add-test-file`.
these can also be editing using the standard text editing UI or an external text editor.

during development, can have a pane where user can write in `test-steps` for more integrated initial development

Still TODO: add another poke to `%save-test` to convert a test into a file and save it in the project dir.