### PR TITLE
wallet: add batch ID to %finished-transaction updates, for apps

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -455,7 +455,6 @@
       (watch-for-batches our.bowl 0x0)
     ?.  ?=(%fact -.sign)  (on-agent:def wire sign)
     =/  upd  !<(update:ui q.cage.sign)
-    ~&  >>  upd
     ?.  ?=(%batch-order -.upd)  `this
     ?~  batch-order.upd         `this
     =/  batch-hash=@ux  (rear batch-order.upd)

--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -16,13 +16,13 @@
   [%give %fact ~[/tx-updates] %wallet-frontend-update !>(-)]
 ::
 ++  finished-tx-update-card
-  |=  in=[@ux origin transaction:smart supported-actions output:eng]
+  |=  in=[@ux finished-transaction]
   ^-  card
   =+  `wallet-frontend-update`[%finished-tx in]
   [%give %fact ~[/tx-updates] %wallet-frontend-update !>(-)]
 ::
 ++  notify-origin-card
-  |=  [our=@p in=[@ux =origin transaction:smart supported-actions output:eng]]
+  |=  [our=@p in=[@ux finished-transaction]]
   ^-  card
   ?~  origin.in  !!
   :*  %pass  q.u.origin.in
@@ -34,7 +34,7 @@
 ::
 ++  get-sent-history
   |=  [=address:smart newest=? our=@p now=@da]
-  ^-  (map @ux [origin transaction:smart supported-actions output:eng])
+  ^-  (map @ux finished-transaction)
   =/  transaction-history=update:ui
     .^  update:ui
         %gx
@@ -45,11 +45,14 @@
   ?~  transaction-history  ~
   ?.  ?=(%transaction -.transaction-history)  ~
   %-  ~(urn by transactions.transaction-history)
-  |=  [hash=@ux @ * =transaction:smart =output:eng]
-  :^    ~
-      transaction(status (add 200 `@`status.transaction))
-    [%noun calldata.transaction]
-  output
+  |=  [hash=@ux t=transaction-update-value:ui]
+  ^-  finished-transaction
+  :*  ~
+      batch-id.location.t
+      transaction.t(status (add 200 `@`status.transaction.t))
+      [%noun calldata.transaction.t]
+      output.t
+  ==
 ::
 ++  watch-for-batches
   |=  [our=@p town=@ux]
@@ -250,11 +253,12 @@
     |=([prop=@tas val=@t] [prop [%s val]])
   ::
   ++  transaction-with-output
-    |=  [hash=@ux =origin t=transaction:smart action=supported-actions o=output:eng]
+    |=  [hash=@ux f=finished-transaction]
     :-  (scot %ux hash)
     %-  pairs
-    :~  ['transaction' (transaction hash t action)]
-        ['output' (output o)]
+    :~  ['transaction' (transaction hash transaction.f action.f)]
+        ['batch' [%s (scot %ux batch.f)]]
+        ['output' (output output.f)]
     ==
   ::
   ++  transaction-no-output

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -33,7 +33,10 @@
 ::
 +$  transaction-store
   %+  map  address:smart
-  (map @ux [=origin =transaction:smart action=supported-actions =output:eng])
+  (map @ux finished-transaction)
+
++$  finished-transaction
+  [=origin batch=@ux =transaction:smart action=supported-actions =output:eng]
 ::
 +$  pending-store
   %+  map  address:smart
@@ -73,12 +76,7 @@
           =transaction:smart
           action=supported-actions
       ==
-      $:  %finished-transaction
-          =origin
-          =transaction:smart
-          action=supported-actions
-          =output:eng
-      ==
+      [%finished-transaction finished-transaction]
   ==
 ::
 ::  sent to web interface
@@ -89,10 +87,7 @@
       [%tx-status hash=@ux =transaction:smart action=supported-actions]
       $:  %finished-tx
           hash=@ux
-          =origin
-          =transaction:smart
-          action=supported-actions
-          =output:eng
+          finished-transaction
       ==
   ==
 ::


### PR DESCRIPTION
We're adding batch IDs to the update that wallet gives on transaction completion. This will allow other apps that build and track transactions to more effectively notify their peers. I was running into a bad race condition on %pokur where you'd notify the host about a new escrow transaction, but the host hadn't yet received the batch that contained the transaction. When it went to check relevant chain-data, it found nothing. 

You can imagine that a peer might actually be several batches behind. So, in situations like this you'll want to send the batch hash and have your peer wait until they're aware of that batch, then check your transaction.

(**state transition included and tested from 0.0.8, replacing current one in next/smart**)