### PR TITLE
uqbar.hoon: add a poke to open faucets

### DIFF
--- a/app/faucet.hoon
+++ b/app/faucet.hoon
@@ -64,6 +64,8 @@
   ?+  mark  (on-poke:def mark vase)
     %faucet-action     (handle-action !<(action:f vase))
     %faucet-configure  (handle-configure !<(configure:f vase))
+    ::  can safely ignore updates from wallet about status of transactions
+    %wallet-update     `this
   ==
   ::
   ++  handle-action

--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -3,10 +3,10 @@
 ::  The agent for interacting with Uqbar. Provides read/write layer for userspace agents.
 ::
 /-  spider,
+    f=zig-faucet,
     u=zig-uqbar,
     ui=zig-indexer,
-    w=zig-wallet,
-    f=zig-faucet
+    w=zig-wallet
 /+  agentio,
     default-agent,
     dbug,

--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -5,7 +5,8 @@
 /-  spider,
     u=zig-uqbar,
     ui=zig-indexer,
-    w=zig-wallet
+    w=zig-wallet,
+    f=zig-faucet
 /+  agentio,
     default-agent,
     dbug,
@@ -196,6 +197,17 @@
             indexer-sources
           (~(gas by *(map id:smart (set dock))) towns.act)
         ==
+      ::
+          %open-faucet
+        ::  poke known sequencer for this town, will fail if they don't
+        ::  host a faucet.
+        :_  state
+        :_  ~
+        %+  ~(poke pass:io /poke-faucet)
+          [q:(~(got by sequencers) town.act) %faucet]
+        :-  %faucet-action
+        !>  ^-  action:f
+        [%open town.act send-to.act]
       ==
       ::
       ++  remove-from-ping-results

--- a/mar/uqbar/action.hoon
+++ b/mar/uqbar/action.hoon
@@ -1,4 +1,5 @@
 /-  u=zig-uqbar
+=,  dejs:format
 ::
 |_  =action:u
 ++  grab
@@ -19,7 +20,7 @@
 ::
 ++  grow
   |%
-  ++  noun  write
+  ++  noun  action
   --
 ::
 ++  grad  %noun

--- a/mar/uqbar/action.hoon
+++ b/mar/uqbar/action.hoon
@@ -1,0 +1,27 @@
+/-  u=zig-uqbar
+::
+|_  =action:u
+++  grab
+  |%
+  ++  noun  action:u
+  ++  json
+    |=  jon=^json
+    |^
+    %-  action:u
+    (action jon)
+    ++  action
+      %-  of
+      :~  [%open-faucet (ot ~[[%town (se %ux)] [%send-to (se %ux)]])]
+          ::  we never accept other pokes from FE
+      ==
+    --
+  --
+::
+++  grow
+  |%
+  ++  noun  write
+  --
+::
+++  grad  %noun
+::
+--

--- a/sur/zig/uqbar.hoon
+++ b/sur/zig/uqbar.hoon
@@ -8,6 +8,7 @@
       [%add-source town=id:smart source=dock]
       [%remove-source town=id:smart source=dock]
       [%set-wallet-source app-name=@tas]  ::  to plug in a third-party wallet app
+      [%open-faucet town=id:smart send-to=address:smart]
       [%ping ~]
   ==
 ::


### PR DESCRIPTION
This PR makes it so we can add a faucet UI to wallet. Since we track active sequencers in uqbar.hoon, it makes the most sense to attach this poke there -- sequencers will usually host faucets, and if this changes, uqbar.hoon should track faucet hosts. 

Tested on fakeships, will need to build usage into wallet FE.