### PR TITLE
add pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,11 @@
+**Problem**:
+
+<A brief description of the problem, along with necessary context.>
+
+**Solution**:
+
+<A brief description of how you solved the problem.>
+
+**Notes**:
+
+<Any other information useful for reviewers.>


### PR DESCRIPTION
**Problem**:

We don't have a standardized way to communicate what a PR is solving and how we solved it.

**Solution**:

Add a PR template. The template proposed in d110c37 is concise but gives an outline for a PR description that can be very helpful for reviewers to understand a PR.

**Notes**:

See docs for discussion of how Github does PR templates: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

FYI @0x70b1a5 @tadad @willbach : let me know if you have any comments. Is this useful? A waste of time? Would a different template be better?