### PR TITLE
pyro: rearrange pokes; allow FE pokes

### DIFF
--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -120,35 +120,55 @@
     |=  =path
     ^-  (unit (unit cage))
     ?+    path  ~
-        [%x %fleet-snap ^]  ``pyro-update+!>((~(has by fleet-snaps) t.t.path))
-        [%x %fleets ~]      ``pyro-update+!>(~(key by fleet-snaps))
-        [%x %ships ~]       ``pyro-update+!>(~(key by piers))
-        [%x %fresh-pier-keys ~]  ``pyro-update+!>(~(key by fresh-piers))
-        [%x %pill ~]        ``pill+!>(pil)
-        [%x %fleet-sizes ^]
-      ?~  fleet=(~(get by fleet-snaps) t.t.path)  ~
+        [%x %fleet-snap ^]
       :^  ~  ~  %pyro-update
-      !>
+      !>  ^-  update
+      [%fleet-snap t.t.path (~(has by fleet-snaps) t.t.path)]
+    ::
+        [%x %fleets ~]
+      :^  ~  ~  %pyro-update
+      !>(`update`[%fleets ~(key by fleet-snaps)])
+    ::
+        [%x %ships ~]
+      :^  ~  ~  %pyro-update
+      !>(`update`[%ships ~(key by piers)])
+    ::
+        [%x %fresh-pier-keys ~]
+      :^  ~  ~  %pyro-update
+      !>(`update`[%fresh-pier-keys ~(key by fresh-piers)])
+    ::
+        [%x %fleet-sizes ^]
+      =+  fleet=(~(get by fleet-snaps) t.t.path)
+      :^  ~  ~  %pyro-update
+      !>  ^-  update
+      ?~  fleet  ~
+      :+  %fleet-sizes  t.t.path
       %-  ~(run by u.fleet)
       |=  p=pier
       [(lent event-log.p) ~(wyt in next-events.p)]
     ::
-        [%x %is-next-events-empty ~]
-      :^  ~  ~  %noun
-      !>   ^-  ?
-      %+  levy  ~(val by piers)
-      |=([p=pier] =(0 ~(wyt in next-events.p)))
-    ::
         [%x %events ~]
       :^  ~  ~  %pyro-update
-      !>
+      !>  ^-  update
+      :-  %events
       %-  ~(run by piers)
       |=  p=pier
       [(lent event-log.p) ~(wyt in next-events.p)]
     ::
         [%x %fleet-ships ^]
       =+  sips=(~(get by fleet-snaps) t.t.path)
-      ?~  sips  ~  ``pyro-update+!>(~(key by u.sips))
+      :^  ~  ~  %pyro-update
+      !>  ^-  update
+      ?~  sips  ~
+      [%fleet-ships t.t.path ~(key by u.sips)]
+    ::
+        [%x %pill ~]  ``pill+!>(pil)
+    ::
+        [%x %is-next-events-empty ~]
+      :^  ~  ~  %noun
+      !>   ^-  ?
+      %+  levy  ~(val by piers)
+      |=([p=pier] =(0 ~(wyt in next-events.p)))
     ::
     ::  scry into running virtual ships
     ::  ship, care, ship, desk, time, path     

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -641,11 +641,8 @@
     ~&  %pyro^%import-fresh-piers^jam-file-path.act^piers-hash^~(key by imported-fresh-piers)
     `state(fresh-piers imported-fresh-piers)
   ::
-      %clear-snaps
-    `state(fleet-snaps ~)
-  ::
-      %pill
-    (poke-pill pill.act)
+      %clear-snaps  `state(fleet-snaps ~)
+      %pill  (poke-pill pill.act)
   ::
       %swap-files
     ::  %pyro must have a functional pill containing %base BEFORE

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -64,9 +64,9 @@
       def        ~(. (default-agent this %|) bowl)
   ++  on-init
     :_  this
-    :~  [%pass / %agent [our dap]:bowl %poke %pill !>(cached-pill)]
-        [%pass / %agent [our dap]:bowl %poke %action !>([%import-snap /testnet/jam /testnet])]
-        :: [%pass / %agent [our dap]:bowl %poke %action !>([%import-fresh-piers /zig/lib/py/fresh-piers/jam])]
+    :~  [%pass / %agent [our dap]:bowl %poke %pyro-action !>([%pill cached-pill])]
+        [%pass / %agent [our dap]:bowl %poke %pyro-action !>([%import-snap /testnet/jam /testnet])]
+        :: [%pass / %agent [our dap]:bowl %poke %pyro-action !>([%import-fresh-piers /zig/lib/py/fresh-piers/jam])]
     ==
   ++  on-save  !>(state)
   ++  on-load
@@ -89,9 +89,7 @@
     =^  cards  state
       ?+  mark  ~|([%aqua-bad-mark mark] !!)
         %aqua-events  (poke-aqua-events:ac !<((list aqua-event) vase))
-        %pill         (poke-pill:ac !<(pill vase))
-        %noun         (poke-noun:ac !<(* vase))
-        %action       (poke-action:ac our.bowl !<(pyro-action vase))
+        %pyro-action  (poke-action:ac our.bowl !<(action vase))
       ==
     [cards this]
   ::
@@ -440,99 +438,6 @@
   =.  this  abet-pe:plow:(pe u.who)
   $
 ::
-::  Load a pill and assemble arvo.  Doesn't send any of the initial
-::  events.
-::
-++  poke-pill
-  |=  p=pill
-  ^-  (quip card:agent:gall _state)
-  ?<  ?=(%ivory -.p)
-  =.  userspace-ova.p
-    ::  if there is an azimuth-snapshot in the pill, we stub it out,
-    ::  since it would interfere with aqua's azimuth simulation.
-    ::
-    ^+  userspace-ova.p
-    %+  turn  userspace-ova.p
-    |=  e=unix-event:pill-lib
-    ^+  e
-    ?.  ?=(%park -.q.e)   e
-    ?.  ?=(%& -.yok.q.e)  e
-    =-  e(q.p.yok.q -)
-    ^-  (map path (each page lobe:clay))
-    %-  ~(urn by q.p.yok.q.e)
-    |=  [=path fil=(each page lobe:clay)]
-    ^+  fil
-    ?.  =(/app/azimuth/version-0/azimuth-snapshot path)  fil
-    ?:  ?=(%| -.fil)  fil
-    &+azimuth-snapshot+[%0 [0x0 0] *^state:naive ~ ~]
-  =.  this  apex-aqua  =<  abet-aqua
-  =.  pil  p
-  ~&  lent=(met 3 (jam boot-ova.pil))
-  =/  res=toon :: (each * (list tank))
-    (mock [boot-ova.pil [2 [0 3] [0 2]]] scry)
-  =.  fleet-snaps  ~
-  ?-  -.res
-      %0
-    ~&  >  "successfully assembled pill"
-    =.  assembled  +7.p.res
-    =.  fresh-piers  ~
-    this
-  ::
-      %1
-    ~&  [%vere-blocked p.res]
-    this
-  ::
-      %2
-    ~&  %vere-fail
-    %-  (slog p.res)
-    this
-  ==
-::
-::  Handle commands from CLI
-::
-::    Should put some thought into arg structure, maybe make a mark.
-::
-::    Should convert some of these to just rewrite into ++poke-events.
-::
-++  poke-noun
-  |=  val=*
-  ^-  (quip card:agent:gall _state)
-  =.  this  apex-aqua  =<  abet-aqua
-  ^+  this
-  ?+  val  ~|(%bad-noun-arg !!)
-      [%swap-files des=@tas]
-    ::  %pyro must have a functional pill containing %base BEFORE
-    ::  another desk can be added with this poke!
-    =.  userspace-ova.pil
-      :_  ~
-      %-  unix-event:pill-lib
-      ::  take all files from a userspace desk
-      %+  %*(. file-ovum:pill-lib directories ~[/])
-      des.val  /(scot %p our.hid)/[des.val]/(scot %da now.hid)
-    =^  ms  state  (poke-pill pil)
-    (emit-cards ms)
-  ::
-      [%wish hers=* p=@t]
-    %+  turn-ships  ((list ship) hers.val)
-    |=  [who=ship thus=_this]
-    =.  this  thus
-    (wish:(pe who) p.val)
-  ::
-      [%unpause-events hers=*]
-    ::  =.  this  start-azimuth-timer
-    %+  turn-ships  ((list ship) hers.val)
-    |=  [who=ship thus=_this]
-    =.  this  thus
-    start-processing-events:(pe who)
-  ::
-      [%pause-events hers=*]
-    ::  =.  this  stop-azimuth-timer
-    %+  turn-ships  ((list ship) hers.val)
-    |=  [who=ship thus=_this]
-    =.  this  thus
-    stop-processing-events:(pe who)
-  ==
-::
 ::  Apply a list of events tagged by ship
 ::
 ++  poke-aqua-events
@@ -590,9 +495,6 @@
       abet-pe:ahoy:[ae initted]
     (pe who.ae)
   ::
-      %pause-events
-    stop-processing-events:(pe who.ae)
-  ::
       %event
     ~?  &(aqua-debug=| !?=(?(%belt %hear) -.q.ue.ae))
       raw-event=[who.ae -.q.ue.ae]
@@ -602,7 +504,7 @@
   ==
 ::
 ++  poke-action
-  |=  [our=ship act=pyro-action]
+  |=  [our=ship act=action]
   ^-  (quip card:agent:gall _state)
   |^
   ?-    -.act
@@ -721,14 +623,106 @@
   ::
       %clear-snaps
     `state(fleet-snaps ~)
+  ::
+      %pill
+    (poke-pill pill.act)
+  ::
+      %swap-files
+    ::  %pyro must have a functional pill containing %base BEFORE
+    ::  another desk can be added with this poke!
+    =.  this  apex-aqua  =<  abet-aqua
+    ^+  this
+    =.  userspace-ova.pil
+      :_  ~
+      %-  unix-event:pill-lib
+      ::  take all files from a userspace desk
+      %+  %*(. file-ovum:pill-lib directories ~[/])
+      des.act  /(scot %p our.hid)/[des.act]/(scot %da now.hid)
+    =^  ms  state  (poke-pill pil)
+    (emit-cards ms)
+  ::
+      %wish
+    =.  this  apex-aqua  =<  abet-aqua
+    ^+  this
+    %+  turn-ships  hers.act
+    |=  [who=ship thus=_this]
+    =.  this  thus
+    (wish:(pe who) p.act)
+  ::
+      %unpause-events
+    =.  this  apex-aqua  =<  abet-aqua
+    ^+  this
+    ::  =.  this  start-azimuth-timer
+    %+  turn-ships  hers.act
+    |=  [who=ship thus=_this]
+    =.  this  thus
+    start-processing-events:(pe who)
+  ::
+      %pause-events
+    =.  this  apex-aqua  =<  abet-aqua
+    ^+  this
+    ::  =.  this  stop-azimuth-timer
+    %+  turn-ships  hers.act
+    |=  [who=ship thus=_this]
+    =.  this  thus
+    stop-processing-events:(pe who)
   ::  %touch-file
   ::  %start-app/%poke-app
   ==
+  ::
   ++  send-events
     |=  events=(list aqua-event)
     ^-  (list card:agent:gall)
     =+  [%aqua-events !>(events)]
     [%pass /self-poke %agent [our %pyro] %poke -]~
+  ::
+  ::  Load a pill and assemble arvo.  Doesn't send any of the initial
+  ::  events.
+  ::
+  ++  poke-pill
+    |=  p=pill
+    ^-  (quip card:agent:gall _state)
+    ?<  ?=(%ivory -.p)
+    =.  userspace-ova.p
+      ::  if there is an azimuth-snapshot in the pill, we stub it out,
+      ::  since it would interfere with aqua's azimuth simulation.
+      ::
+      ^+  userspace-ova.p
+      %+  turn  userspace-ova.p
+      |=  e=unix-event:pill-lib
+      ^+  e
+      ?.  ?=(%park -.q.e)   e
+      ?.  ?=(%& -.yok.q.e)  e
+      =-  e(q.p.yok.q -)
+      ^-  (map path (each page lobe:clay))
+      %-  ~(urn by q.p.yok.q.e)
+      |=  [=path fil=(each page lobe:clay)]
+      ^+  fil
+      ?.  =(/app/azimuth/version-0/azimuth-snapshot path)  fil
+      ?:  ?=(%| -.fil)  fil
+      &+azimuth-snapshot+[%0 [0x0 0] *^state:naive ~ ~]
+    =.  this  apex-aqua  =<  abet-aqua
+    =.  pil  p
+    ~&  lent=(met 3 (jam boot-ova.pil))
+    =/  res=toon :: (each * (list tank))
+      (mock [boot-ova.pil [2 [0 3] [0 2]]] scry)
+    =.  fleet-snaps  ~
+    ?-  -.res
+        %0
+      ~&  >  "successfully assembled pill"
+      =.  assembled  +7.p.res
+      =.  fresh-piers  ~
+      this
+    ::
+        %1
+      ~&  [%vere-blocked p.res]
+      this
+    ::
+        %2
+      ~&  %vere-fail
+      %-  (slog p.res)
+      this
+    ==
   --
 ::
 ::  Run a callback function against a list of ships, aggregating state

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -120,14 +120,14 @@
     |=  =path
     ^-  (unit (unit cage))
     ?+    path  ~
-        [%x %fleet-snap ^]  ``noun+!>((~(has by fleet-snaps) t.t.path))
-        [%x %fleets ~]      ``noun+!>(~(key by fleet-snaps))
-        [%x %ships ~]       ``noun+!>(~(key by piers))
-        [%x %fresh-pier-keys ~]  ``noun+!>(~(key by fresh-piers))
+        [%x %fleet-snap ^]  ``pyro-update+!>((~(has by fleet-snaps) t.t.path))
+        [%x %fleets ~]      ``pyro-update+!>(~(key by fleet-snaps))
+        [%x %ships ~]       ``pyro-update+!>(~(key by piers))
+        [%x %fresh-pier-keys ~]  ``pyro-update+!>(~(key by fresh-piers))
         [%x %pill ~]        ``pill+!>(pil)
         [%x %fleet-sizes ^]
       ?~  fleet=(~(get by fleet-snaps) t.t.path)  ~
-      :^  ~  ~  %noun
+      :^  ~  ~  %pyro-update
       !>
       %-  ~(run by u.fleet)
       |=  p=pier
@@ -140,7 +140,7 @@
       |=([p=pier] =(0 ~(wyt in next-events.p)))
     ::
         [%x %events ~]
-      :^  ~  ~  %noun
+      :^  ~  ~  %pyro-update
       !>
       %-  ~(run by piers)
       |=  p=pier
@@ -148,7 +148,7 @@
     ::
         [%x %fleet-ships ^]
       =+  sips=(~(get by fleet-snaps) t.t.path)
-      ?~  sips  ~  ``noun+!>(~(key by u.sips))
+      ?~  sips  ~  ``pyro-update+!>(~(key by u.sips))
     ::
     ::  scry into running virtual ships
     ::  ship, care, ship, desk, time, path     

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -729,7 +729,7 @@
       :_  state(pyro-ships-ready ~)
       :+  (~(watch-our pass:io /restore) /effect/restore)
         %+  ~(poke-our pass:io /self-wire)  %pyro
-        [%action !>([%restore-snap snap.act])]
+        [%pyro-action !>([%restore-snap snap.act])]
       ~
     ::
         %publish-app  :: TODO

--- a/gen/pyro/stop.hoon
+++ b/gen/pyro/stop.hoon
@@ -3,5 +3,5 @@
 /-  *pyro
 :-  %say
 |=  [* [her=ship ~] ~]
-:-  %action
+:-  %pyro-action
 [%remove-ship her]

--- a/lib/zig/pyro.hoon
+++ b/lib/zig/pyro.hoon
@@ -60,6 +60,84 @@
   |=  [who=@p to=@p app=@tas =path]
   (poke who who %subscriber %subscriber-action [%sub to app path])
 ::
+++  enjs
+  =,  enjs:format
+  |%
+  ++  update
+    |=  =^update
+    ^-  json
+    ?-    -.update
+        %fleet-snap
+      (frond -.update (fleet-snap [path has-path]:update))
+    ::
+        %fleets
+      (frond -.update (fleets snap-paths.update))
+    ::
+        %ships
+      (frond -.update (set-ships ships.update))
+    ::
+        %fresh-pier-keys
+      (frond -.update (frond %ships (set-ships ships.update)))
+    ::
+        %fleet-sizes
+      (frond -.update (events events.update))
+    ::
+        %events
+      (events events.update)
+    ::
+        %fleet-ships
+      (frond -.update (fleet-ships [path ships]:update))
+    ==
+  ::
+  ++  fleet-snap
+    |=  [p=^path has-path=?]
+    ^-  json
+    %-  pairs
+    :+  [%path (path p)]
+      [%has-path [%b has-path]]
+    ~
+  ::
+  ++  fleets
+    |=  snap-paths=(set ^path)
+    ^-  json
+    (frond %snap-paths (set-paths snap-paths))
+  ::
+  ++  events
+    |=  events=(map @p [events-done=@ud events-qued=@ud])
+    ^-  json
+    %+  frond  %events
+    %-  pairs
+    %+  turn  ~(tap by events)
+    |=  [who=@p events-done=@ud events-qued=@ud]
+    :-  (scot %p who)
+    %-  pairs
+    :+  [%events-done (numb events-done)]
+      [%events-qued (numb events-qued)]
+    ~
+  ::
+  ++  fleet-ships
+    |=  [p=^path ships=(set @p)]
+    ^-  json
+    %-  pairs
+    :+  [%path (path p)]
+      [%ships (set-ships ships)]
+    ~
+  ::
+  ++  set-ships
+    |=  ships=(set @p)
+    ^-  json
+    :-  %a
+    %+  turn  ~(tap in ships)
+    |=(who=@p [%s (scot %p who)])
+  ::
+  ++  set-paths
+    |=  paths=(set ^path)
+    ^-  json
+    :-  %a
+    %+  turn  ~(tap in paths)
+    |=(p=^path (path p))
+  --
+::
 ++  dejs
   =,  dejs:format
   |%

--- a/lib/zig/pyro.hoon
+++ b/lib/zig/pyro.hoon
@@ -59,4 +59,26 @@
 ++  subscribe
   |=  [who=@p to=@p app=@tas =path]
   (poke who who %subscriber %subscriber-action [%sub to app path])
+::
+++  dejs
+  =,  dejs:format
+  |%
+  ++  action
+    %-  of
+    :~  [%remove-ship (ot ~[[%who (se %p)]])]
+        [%snap-ships (ot ~[[%path pa] [%hers (ar (se %p))]])]
+        [%restore-snap (ot ~[[%path pa]])]
+        [%clear-snap (ot ~[[%path pa]])]
+        [%export-snap (ot ~[[%path pa]])]
+        [%import-snap (ot ~[[%jam-file-path pa] [%snap-label pa]])]
+        [%export-fresh-piers ul]
+        [%import-fresh-piers (ot ~[[%jam-file-path pa]])]
+        [%clear-snaps ul]
+        :: [%pill ]
+        [%swap-files (ot ~[[%des (se %tas)]])]
+        [%wish (ot ~[[%hers (ar (se %p))] [%p so]])]
+        [%unpause-events (ot ~[[%hers (ar (se %p))]])]
+        [%pause-events (ot ~[[%hers (ar (se %p))]])]
+    ==
+  --
 --

--- a/lib/zig/pyro.hoon
+++ b/lib/zig/pyro.hoon
@@ -66,6 +66,7 @@
   ++  update
     |=  =^update
     ^-  json
+    ?~  update  ~
     ?-    -.update
         %fleet-snap
       (frond -.update (fleet-snap [path has-path]:update))

--- a/mar/pyro/action.hoon
+++ b/mar/pyro/action.hoon
@@ -1,0 +1,21 @@
+/-  pyro=zig-pyro
+/+  pyro-lib=zig-pyro
+::
+=,  dejs:format
+|_  =action:pyro
+++  grab
+  |%
+  ++  noun  action:pyro
+  ++  json
+    |=  jon=^json
+    ^-  action:pyro
+    (action:pyro action:dejs:pyro-lib jon)
+  --
+::
+++  grow
+  |%
+  ++  noun  action
+  --
+::
+++  grad  %noun
+--

--- a/mar/pyro/update.hoon
+++ b/mar/pyro/update.hoon
@@ -1,0 +1,17 @@
+/-  pyro=zig-pyro
+/+  pyro-lib=zig-pyro
+|_  =update:pyro
+::
+++  grab
+  |%
+  ++  noun  update:pyro
+  --
+::
+++  grow
+  |%
+  ++  noun  update
+  ++  json  (update:enjs:pyro-lib update)
+  --
+::
+++  grad  %noun
+--

--- a/sur/zig/pyro.hoon
+++ b/sur/zig/pyro.hoon
@@ -32,11 +32,10 @@
 ::
 +$  aqua-event
   $%  [%init-ship who=ship]
-      [%pause-events who=ship]
       [%event who=ship ue=unix-event]
   ==
 ::
-+$  pyro-action
++$  action
   $%  [%remove-ship who=ship]
       [%snap-ships =path hers=(list ship)]
       [%restore-snap =path]
@@ -46,6 +45,11 @@
       [%export-fresh-piers ~]
       [%import-fresh-piers jam-file-path=path]
       [%clear-snaps ~]
+      [%pill =pill]
+      [%swap-files des=@tas]
+      [%wish hers=(list ship) p=@t]
+      [%unpause-events hers=(list ship)]
+      [%pause-events hers=(list ship)]  ::  TODO: do we need this at events And 
   ==
 ::
 +$  vane  ?(%a %b %c %d %e %g %i %j %k)

--- a/sur/zig/pyro.hoon
+++ b/sur/zig/pyro.hoon
@@ -53,11 +53,12 @@
   ==
 ::
 ++  update
+  $@  ~
   $%  [%fleet-snap =path has-path=?]
       [%fleets snap-paths=(set path)]
       [%ships ships=(set ship)]
       [%fresh-pier-keys ships=(set ship)]
-      [%fleet-sizes events=(map ship [events-done=@ud events-qued=@ud])]
+      [%fleet-sizes =path events=(map ship [events-done=@ud events-qued=@ud])]
       [%events events=(map ship [events-done=@ud events-qued=@ud])]
       [%fleet-ships =path ships=(set ship)]
   ==

--- a/sur/zig/pyro.hoon
+++ b/sur/zig/pyro.hoon
@@ -52,6 +52,16 @@
       [%pause-events hers=(list ship)]  ::  TODO: do we need this at events And 
   ==
 ::
+++  update
+  $%  [%fleet-snap =path has-path=?]
+      [%fleets snap-paths=(set path)]
+      [%ships ships=(set ship)]
+      [%fresh-pier-keys ships=(set ship)]
+      [%fleet-sizes events=(map ship [events-done=@ud events-qued=@ud])]
+      [%events events=(map ship [events-done=@ud events-qued=@ud])]
+      [%fleet-ships =path ships=(set ship)]
+  ==
+::
 +$  vane  ?(%a %b %c %d %e %g %i %j %k)
 ::
 +$  aqua-effects

--- a/ted/ziggurat/test/run.hoon
+++ b/ted/ziggurat/test/run.hoon
@@ -270,8 +270,8 @@
   ?~  snapshot-ships  (pure:m ~)
   ;<  ~  bind:m
     %+  poke-our  %pyro
-    :-  %action
-    !>  ^-  pyro-action:pyro
+    :-  %pyro-action
+    !>  ^-  action:pyro
     :+  %snap-ships
       ?~  test-id  /[project-id]/(scot %ud step)
       /[project-id]/(scot %ux u.test-id)/(scot %ud step)


### PR DESCRIPTION
**Problem**:

Frontend cannot interact with %pyro.

**Solution**:

Rearrange %pyro and add `+enjs` and `+dejs` cores and appropriate `mar` files.

**Notes**:

~~WIP~~

I'll do a similar unification for %ziggurat scries/sub updates in #355 to reduce merge headaches.