### PR TITLE
wallet: fixed ++  make-tokens bug

### DIFF
--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -67,8 +67,8 @@
   |-  ::  scry for each tracked address
   ?~  addrs  new
   =/  upd  .^(update:ui %gx /(scot %p our)/uqbar/(scot %da now)/indexer/newest/holder/0x0/(scot %ux i.addrs)/noun)
-  ?~  upd  new
-  ?.  ?=(%item -.upd)
+  ?.  ?~  upd  %.y
+      ?=(%item -.upd)
     ::  handle newest-item update type
     ?>  ?=(%newest-item -.upd)
     =/  single=asset
@@ -83,7 +83,7 @@
       ==
   %=  $
     addrs  t.addrs
-    new  (~(put by new) i.addrs (indexer-update-to-book upd))
+    new  ?~(upd new (~(put by new) i.addrs (indexer-update-to-book upd)))
   ==
 ::
 ++  indexer-update-to-book

--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -67,8 +67,8 @@
   |-  ::  scry for each tracked address
   ?~  addrs  new
   =/  upd  .^(update:ui %gx /(scot %p our)/uqbar/(scot %da now)/indexer/newest/holder/0x0/(scot %ux i.addrs)/noun)
-  ?.  ?~  upd  %.y
-      ?=(%item -.upd)
+  ?~  upd  $(addrs t.addrs)
+  ?.  ?=(%item -.upd)
     ::  handle newest-item update type
     ?>  ?=(%newest-item -.upd)
     =/  single=asset
@@ -83,7 +83,7 @@
       ==
   %=  $
     addrs  t.addrs
-    new  ?~(upd new (~(put by new) i.addrs (indexer-update-to-book upd)))
+    new  (~(put by new) i.addrs (indexer-update-to-book upd))
   ==
 ::
 ++  indexer-update-to-book


### PR DESCRIPTION
**Problem**:

When you derive a new address or add a tracked address, all of the tokens from all other wallets disappear.

**Solution**:

In the make-tokens arm, when the token scry for the new address is null (it will be the first in the list of addresses), the trap just escapes rather than iterating through the rest of the addresses. I changed the ?~ to continue to the $ recursion.

