### PR TITLE
ziggurat: add %pyro-ships-ready update and scry

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -870,10 +870,15 @@
       update-info
     ::
         %stop-pyro-ships
-      :_  state(pyro-ships-ready ~)
-      :~  [%give %fact [/pyro-done]~ [%noun !>(`*`**)]]
+      =.  pyro-ships-ready  ~
+      :_  state
+      :^    [%give %fact [/pyro-done]~ [%noun !>(`*`**)]]
           [%give %kick [/pyro-done]~ ~]
-      ==
+        %+  update-vase-to-card:zig-lib  ''
+        %.  pyro-ships-ready
+        %~  pyro-ships-ready  make-update-vase:zig-lib
+        ['' %pyro-ships-ready ~]
+      ~
     ::
         %start-pyro-ships
       =?  ships.act  ?=(~ ships.act)  ~[~nec ~bud]
@@ -1067,9 +1072,13 @@
       ?~  test-queue                         [leave^~ this]
       ?.  (~(all by pyro-ships-ready) same)  [leave^~ this]
       :_  this
-      :+  leave
-        %-  ~(poke-self pass:io /self-wire)
-        [%ziggurat-action !>(`action:zig`%$^~^[%run-queue ~])]
+      :^    leave
+          %-  ~(poke-self pass:io /self-wire)
+          [%ziggurat-action !>(`action:zig`%$^~^[%run-queue ~])]
+        %+  update-vase-to-card:zig-lib  ''
+        %.  pyro-ships-ready
+        %~  pyro-ships-ready  make-update-vase:zig-lib
+        ['' %pyro-ships-ready ~]
       ~
     ==
   ::
@@ -1135,6 +1144,13 @@
     ?~  project  !>(`update:zig`~)
     %.  u.project
     ~(project make-update-vase:zig-lib [project-name %project ~])
+  ::
+      [%pyro-ships-ready ~]
+    :^  ~  ~  %ziggurat-update
+    %.  pyro-ships-ready
+    %~  pyro-ships-ready  make-update-vase:zig-lib
+    ['' %pyro-ships-ready ~]
+  ::
   ::
       [%state @ ~]
     =*  project-name  i.t.t.p

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -162,6 +162,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%dashboard update-info [%& jon] ~]
+  ::
+  ++  pyro-ships-ready
+    |=  pyro-ships-ready=(map @p ?)
+    ^-  vase
+    !>  ^-  update:zig
+    [%pyro-ships-ready update-info [%& pyro-ships-ready] ~]
   --
 ::
 ++  make-error-vase
@@ -293,6 +299,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%dashboard update-info [%| level message] ~]
+  ::
+  ++  pyro-ships-ready
+    |=  message=@t
+    ^-  vase
+    !>  ^-  update:zig
+    [%pyro-ships-ready update-info [%| level message] ~]
   --
 ::
 ++  make-compile-contracts
@@ -1006,6 +1018,12 @@
     ::
         %dashboard
       ['data' p.payload.update]~
+    ::
+        %pyro-ships-ready
+      :_  ~
+      :-  'data'
+      %+  frond  %pyro-ships-ready
+      (pyro-ships-ready p.payload.update)
     ==
   ::
   ++  error
@@ -1347,6 +1365,13 @@
     :-  %a
     %+  turn  ~(tap in cords)
     |=([cord=@t] [%s cord])
+  ::
+  ++  pyro-ships-ready
+    |=  pyro-ships-ready=(map @p ?)
+    %-  pairs
+    %+  turn  ~(tap by pyro-ships-ready)
+    |=  [who=@p is-ready=?]
+    [(scot %p who) [%b is-ready]]
   ::
   ++  single-string-object
     |=  [key=@t error=^tape]

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -8,7 +8,7 @@
   $:  %0
       =projects
       virtualnet-addresses=(map @p address:smart)
-      pyro-ships-ready=(map ship ?)
+      pyro-ships-ready=(map @p ?)
       test-queue=(qeu [project=@t test-id=@ux])
       test-running=?
   ==
@@ -178,6 +178,7 @@
       %test-results
       %dir
       %dashboard
+      %pyro-ships-ready
   ==
 +$  update-level  ?(%success error-level)
 +$  error-level   ?(%info %warning %error)
@@ -209,6 +210,7 @@
       [%test-results update-info payload=(data shown-test-results) test-id=@ux thread-id=@t =test-steps]
       [%dir update-info payload=(data (list path)) ~]
       [%dashboard update-info payload=(data json) ~]
+      [%pyro-ships-ready update-info payload=(data (map @p ?)) ~]
   ==
 ::
 +$  shown-projects  (map @t shown-project)


### PR DESCRIPTION
**Problem**:

FE needs to be able to see what ships are running, according to %ziggurat.

**Solution**:

Add an update, scry path, and send updates for %pyro-ships-ready.

**Notes**:

FYI @0x70b1a5 
