### PR TITLE
ziggurat: add %edit-test

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -661,6 +661,24 @@
       %-  add-and-queue-test-file
       [project name path request-id]:act
     ::
+        %edit-test
+      =/  =project:zig  (~(got by projects) project.act)
+      =^  [cards=(list card) =test:zig]  state
+        (add-test [project name test-imports test-steps request-id]:act)
+      ?:  =(*test:zig test)
+        [cards state]  ::  encountered error  ::  TODO: properly report %edit-test
+      =*  test-id  id.act
+      =.  tests.project  (~(put by tests.project) test-id test)
+      :_  %=  state
+              projects
+            (~(put by projects) project.act project)
+          ==
+      :_  (slag 1 cards)
+      %+  update-vase-to-card:zig-lib  project.act
+      %.  [test test-id]
+      %~  edit-test  make-update-vase:zig-lib
+      update-info
+    ::
         %delete-test
       =/  =project:zig  (~(got by projects) project.act)
       =.  tests.project  (~(del by tests.project) id.act)

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -666,7 +666,9 @@
       =^  [cards=(list card) =test:zig]  state
         (add-test [project name test-imports test-steps request-id]:act)
       ?:  =(*test:zig test)
-        [cards state]  ::  encountered error  ::  TODO: properly report %edit-test
+        :_  state  ::  encountered error
+        ?~  cards  ~
+        ~[(add-test-error-to-edit-test:zig-lib i.cards)]
       =*  test-id  id.act
       =.  tests.project  (~(put by tests.project) test-id test)
       :_  %=  state

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -854,6 +854,22 @@
     ;~(plug sym ;~(pfix gap stap))
   ==
 ::
+++  add-test-error-to-edit-test
+  |=  add-test-card=card
+  ^-  card
+  ?.  ?=(%give -.add-test-card)    add-test-card
+  ?.  ?=(%fact -.p.add-test-card)  add-test-card
+  %=  add-test-card
+      cage.p
+    =*  cage  cage.p.add-test-card
+    :-  p.cage
+    !>  ^-  update:zig
+    =+  !<(=update:zig q.cage)
+    ?~  update  ~
+    ?.  ?=(%add-test -.update)  update
+    :-  %edit-test  +.update
+  ==
+::
 ::  files we delete from zig desk to make new gall desk
 ::
 ++  clean-desk

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -78,6 +78,12 @@
     !>  ^-  update:zig
     [%compile-contract update-info [%& ~] ~]
   ::
+  ++  edit-test
+    |=  [=test:zig test-id=@ux]
+    ^-  vase
+    !>  ^-  update:zig
+    [%edit-test update-info [%& (show-test test)] test-id]
+  ::
   ++  delete-test
     |=  test-id=@ux
     ^-  vase
@@ -213,6 +219,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%compile-contract update-info [%| level message] ~]
+  ::
+  ++  edit-test
+    |=  [message=@t test-id=@ux]
+    ^-  vase
+    !>  ^-  update:zig
+    [%edit-test update-info [%| level message] test-id]
   ::
   ++  delete-test
     |=  [message=@t test-id=@ux]
@@ -958,6 +970,12 @@
       ['data' ~]~
     ::
         %add-test
+      :+  ['test_id' %s (scot %ux test-id.update)]
+        :-  'data'
+        (frond %test (shown-test p.payload.update))
+      ~
+    ::
+        %edit-test
       :+  ['test_id' %s (scot %ux test-id.update)]
         :-  'data'
         (frond %test (shown-test p.payload.update))

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -128,6 +128,7 @@
           [%add-and-run-test-file name=(unit @t) =path]
           [%add-and-queue-test-file name=(unit @t) =path]
       ::
+          [%edit-test id=@ux name=(unit @t) =test-imports =test-steps]
           [%delete-test id=@ux]
           [%run-test id=@ux]
           [%run-queue ~]  ::  can be used as [%$ %run-queue ~]
@@ -163,6 +164,7 @@
       %state
       %new-project
       %add-test
+      %edit-test
       %compile-contract
       %delete-test
       %run-queue
@@ -196,6 +198,7 @@
       [%new-project update-info payload=(data ~) ~]
       [%add-test update-info payload=(data shown-test) test-id=@ux]
       [%compile-contract update-info payload=(data ~) ~]
+      [%edit-test update-info payload=(data shown-test) test-id=@ux]
       [%delete-test update-info payload=(data ~) test-id=@ux]
       [%run-queue update-info payload=(data ~) ~]
       [%add-custom-step update-info payload=(data ~) test-id=@ux tag=@tas]


### PR DESCRIPTION
**Problem**:

Current way to "edit" a test is to %delete-test and then %add-test, but this is not easy for FE.

**Solution**:

Add an %edit-test poke.

**Notes**:

None
