### PR TITLE
ziggurat: add %sync-desk-to-vship scry

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -1260,6 +1260,12 @@
     %~  test-queue  make-update-vase:zig-lib
     ['' %test-queue ~]
   ::
+      [%sync-desk-to-vship ~]
+    :^  ~  ~  %ziggurat-update
+    %.  sync-desk-to-vship
+    %~  sync-desk-to-vship  make-update-vase:zig-lib
+    ['' %sync-desk-to-vship ~]
+  ::
       [%custom-step-compiled @ @ @ ~]
     =*  project-name  i.t.t.p
     =*  test-id       i.t.t.t.p

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -178,6 +178,13 @@
     ^-  vase
     !>  ^-  update:zig
     [%pyro-agent-state update-info [%& agent-state] ~]
+  ::
+  ++  sync-desk-to-vship
+    |=  =sync-desk-to-vship:zig
+    ^-  vase
+    !>  ^-  update:zig
+    :^  %sync-desk-to-vship  update-info
+    [%& sync-desk-to-vship]  ~
   --
 ::
 ++  make-error-vase
@@ -320,6 +327,12 @@
     ^-  vase
     !>  ^-  update:zig
     [%pyro-agent-state update-info [%| level message] ~]
+  ::
+  ++  sync-desk-to-vship
+    |=  message=@t
+    ^-  vase
+    !>  ^-  update:zig
+    [%sync-desk-to-vship update-info [%| level message] ~]
   --
 ::
 ++  make-compile-contracts
@@ -1609,6 +1622,12 @@
       :_  ~
       :-  'data'
       (frond %pyro-agent-state [%s p.payload.update])
+    ::
+        %sync-desk-to-vship
+      :_  ~
+      :-  'data'
+      %+  frond  %sync-desk-to-vship
+      (sync-desk-to-vship p.payload.update)
     ==
   ::
   ++  error

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -212,6 +212,7 @@
       [%poke update-info payload=(data ~) ~]
       [%test-queue update-info payload=(data (qeu [@t @ux])) ~]
       [%pyro-agent-state update-info payload=(data @t) ~]
+      [%sync-desk-to-vship update-info payload=(data sync-desk-to-vship) ~]
   ==
 ::
 +$  shown-projects  (map @t shown-project)


### PR DESCRIPTION
**Problem**:

FE needs to know what ships are currently syncing what desks/projects.

**Solution**:

Add a scry for the `sync-desk-to-vship` state.

**Notes**:

FYI @tadad 