### PR TITLE
ziggurat: improve compiler errors with vang

### DIFF
--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -237,8 +237,8 @@
       :-  (scot %p our.bowl)
       (weld /[project-name]/(scot %da now.bowl) p)
     =/  file-cord=@t  .^(@t %cx file-scry-path)
-    =/  [imports=(list [face=@tas =path]) =hair]
-      (parse-start-of-pile:zig-lib (trip file-cord))
+    =/  [imports=(list [face=@tas =path]) payload=hoon]
+      (parse-pile:conq file-scry-path (trip file-cord))
     =^  subject=(each vase @t)  state
       %^  compile-test-imports:zig-lib  `@tas`project-name
       imports  state
@@ -251,10 +251,7 @@
       %+  update-vase-to-card:zig-lib  project-name
       (add-test-error (crip message) 0x0)
     =/  test-steps-compilation-result=(each vase @t)
-      %-  compile-and-call-arm:zig-lib
-      :^  '$'  p.hair  p.subject
-      %-  of-wain:format
-      (slag (dec p.hair) (to-wain:format file-cord))
+      (compile-and-call-arm:zig-lib '$' p.subject payload)
     ?:  ?=(%| -.test-steps-compilation-result)
       =/  message=tape
         %+  weld  "test-steps compilation failed for"

--- a/gen/build-hash-cache.hoon
+++ b/gen/build-hash-cache.hoon
@@ -8,6 +8,6 @@
 =/  smart-txt        .^(@t %cx /(scot %p our)/zig/(scot %da now)/lib/zig/sys/smart/hoon)
 =/  hoon-txt         .^(@t %cx /(scot %p our)/zig/(scot %da now)/lib/zig/sys/hoon/hoon)
 =/  cax              ;;(cache:conq (cue +.+:;;([* * @] hash-cache-file)))
-=/  new              (conq:conq hoon-txt smart-txt cax gas)
+=/  new              (conq:conq /lib/zig/sys/hoon/hoon hoon-txt smart-txt cax gas)
 ~&  >>  "new hash cache size: {<(met 3 (jam new))>}, with {<~(wyt by new)>} items"
 [%noun new]

--- a/gen/compile.hoon
+++ b/gen/compile.hoon
@@ -1,5 +1,6 @@
 /+  conq=zink-conq
 /*  smart-lib-noun  %noun  /lib/zig/sys/smart-lib/noun
+!.
 :-  %say
 |=  [[now=@da eny=@uvJ bek=beak] [pax=path ~] ~]
 :-  %noun

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -660,6 +660,8 @@
   ::  adapted from compile-contract:conq
   ::  this wacky design is to get a somewhat more helpful error print
   ::
+  ::  TODO: with +vast -> +vang change, do we need this anymore?
+  ::
   |^
   =/  first  (mule |.(parse-main))
   ?:  ?=(%| -.first)
@@ -681,7 +683,7 @@
   ::
   ++  parse-main  ::  first
     ^-  [raw=(list [face=term =path]) contract-hoon=hoon]
-    %-  parse-pile:conq
+    %+  parse-pile:conq  (welp desk to-compile)
     (trip .^(@t %cx (welp desk to-compile)))
   ::
   ++  parse-libs  ::  second
@@ -691,7 +693,7 @@
     |=  [face=term =path]
     ^-  hoon
     :+  %ktts  face
-    +:(parse-pile:conq (trip .^(@t %cx (welp desk (welp path /hoon)))))
+    +:(parse-pile:conq (welp desk (welp path /hoon)) (trip .^(@t %cx (welp desk (welp path /hoon)))))
   ::
   ++  build-libs  ::  third
     |=  braw=(list hoon)
@@ -777,60 +779,30 @@
   res-text
 ::
 ++  noah-slap-ream
-  |=  [number-sur-lines=@ud subject=vase payload=@t]
+  |=  [subject=vase payload=@t]
   ^-  tape
   =/  compilation-result
-    (mule-slap-subject number-sur-lines subject payload)
+    (mule-slap-subject subject (ream payload))
   ?:  ?=(%| -.compilation-result)  (trip payload)
   (noah p.compilation-result)
 ::
 ++  mule-slap-subject
-  |=  [number-sur-lines=@ud subject=vase payload=@t]
+  |=  [subject=vase payload=hoon]
   ^-  (each vase @t)
+  !.
   =/  compilation-result
-    (mule |.((slap subject (ream payload))))
+    (mule |.((slap subject payload)))
   ?:  ?=(%& -.compilation-result)  compilation-result
-  ~&  (get-formatted-error p.compilation-result)
-  =/  error-tanks=(list tank)  (scag 2 p.compilation-result)
-  ?.  ?=([^ [%leaf ^] ~] error-tanks)
-    :-  %|
-    (get-formatted-error (scag 2 p.compilation-result))
-  =/  [error-line-number=@ud col=@ud]
-    (parse-error-line-col p.i.t.error-tanks)
-  =/  real-line-number=@ud
-    (dec (add number-sur-lines error-line-number))
-  =/  modified-error-tanks=(list tank)
-    ~[i.error-tanks [%leaf "\{{<real-line-number>} {<col>}}"]]
-  :-  %|
-  (get-formatted-error (scag 2 modified-error-tanks))
-::
-++  parse-error-line-col
-  |=  line-col=tape
-  ^-  [@ud @ud]
-  =/  [=hair res=(unit [line-col=[@ud @ud] =nail])]
-    %.  [[1 1] line-col]
-    %-  full
-    %+  ifix  [kel ker]
-    ;~(plug dem:ag ;~(pfix ace dem:ag))
-  ?^  res  line-col.u.res
-  %-  mean  %-  flop
-  =/  lyn  p.hair
-  =/  col  q.hair
-  :~  leaf+"syntax error"
-      leaf+"\{{<lyn>} {<col>}}"
-      leaf+(runt [(dec col) '-'] "^")
-      leaf+(trip (snag (dec lyn) (to-wain:format (crip line-col))))
-  ==
+  [%| (get-formatted-error p.compilation-result)]
 ::
 ++  compile-and-call-arm
-  |=  [arm=@tas number-sur-lines=@ud subject=vase payload=@t]
+  |=  [arm=@tas subject=vase payload=hoon]
   ^-  (each vase @t)
   =/  hoon-compilation-result
-    (mule-slap-subject number-sur-lines subject payload)
+    (mule-slap-subject subject payload)
   ?:  ?=(%| -.hoon-compilation-result)
     hoon-compilation-result
-  %^  mule-slap-subject  number-sur-lines
-  p.hoon-compilation-result  arm
+  (mule-slap-subject p.hoon-compilation-result (ream arm))
 ::
 ++  make-recompile-custom-steps-cards
   |=  $:  project-name=@t
@@ -867,8 +839,8 @@
     %+  update-vase-to-card  project-name
     (add-custom-error (crip message) [`@ux`(sham test) tag])
   =/  file-cord=@t  .^(@t %cx file-scry-path)
-  =/  [imports=(list [face=@tas =path]) =hair]
-    (parse-start-of-pile (trip file-cord))
+  =/  [imports=(list [face=@tas =path]) payload=hoon]
+    (parse-pile:conq file-scry-path (trip file-cord))
   ?:  ?=(%| -.subject.test)
     =/  message=tape
       %+  weld  "subject must compile from imports before"
@@ -878,10 +850,9 @@
     %+  update-vase-to-card  project-name
     (add-custom-error (crip message) [`@ux`(sham test) tag])
   =/  compilation-result=(each vase @t)
-    %-  compile-and-call-arm
-    :^  '$'  p.hair  p.subject.test
-    %-  of-wain:format
-    (slag (dec p.hair) (to-wain:format file-cord))
+    (compile-and-call-arm '$' p.subject.test payload)
+    :: %-  of-wain:format
+    :: (slag (dec p.hair) (to-wain:format file-cord))
   ?:  ?=(%| -.compilation-result)
     =/  message=tape
       %+  weld  "compilation failed with error:"
@@ -968,40 +939,6 @@
     ~&  %ziggurat^%scry-and-cache-ca-fail
     ~
   --
-::
-::  abbreviated parser from lib/zink/conq.hoon:
-::   parse to end of imports, start of hoon.
-::   used to find start of hoon for compilation and to find
-::   proper line error number in case of error
-::   (see +mule-slap-subject)
-::
-+$  small-start-of-pile  (list [face=term =path])
-::
-++  parse-start-of-pile
-  |=  tex=tape
-  ^-  [small-start-of-pile hair]
-  =/  [=hair res=(unit [=small-start-of-pile =nail])]
-    (start-of-pile-rule [1 1] tex)
-  ?^  res  [small-start-of-pile.u.res hair]
-  %-  mean  %-  flop
-  =/  lyn  p.hair
-  =/  col  q.hair
-  :~  leaf+"syntax error"
-      leaf+"\{{<lyn>} {<col>}}"
-      leaf+(runt [(dec col) '-'] "^")
-      leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
-  ==
-::
-++  start-of-pile-rule
-  %+  ifix
-    :_  gay
-    ::  parse optional smart library import and ignore
-    ;~(plug gay (punt ;~(plug fas lus gap taut-rule:conq gap)))
-  ;~  plug
-  ::  only accept /= imports for contract libraries
-    %+  rune:conq  tis
-    ;~(plug sym ;~(pfix gap stap))
-  ==
 ::
 ++  town-id-to-sequencer-host
   |=  [project-name=@t town-id=@ux =configs:zig]
@@ -1269,8 +1206,8 @@
   ++  get-configuration-from-file
     ^-  (each configuration-file-output:zig [(list card) inflated-state-0:zig])
     =/  file-cord=@t  .^(@t %cx config-file-path)
-    =/  [imports=(list [face=@tas =path]) =hair]
-      (parse-start-of-pile (trip file-cord))
+    =/  [imports=(list [face=@tas =path]) payload=hoon]
+      (parse-pile:conq config-file-path (trip file-cord))
     =^  subject=(each vase @t)  state
       (compile-test-imports project-name imports state)
     ?:  ?=(%| -.subject)
@@ -1283,9 +1220,7 @@
       %+  update-vase-to-card  project-name
       (new-project-error (crip message))
     =/  config-core
-      %^  mule-slap-subject  p.hair  p.subject
-      %-  of-wain:format
-      (slag (dec p.hair) (to-wain:format file-cord))
+      (mule-slap-subject p.subject payload)
     ?:  ?=(%| -.config-core)
       =/  message=tape
         "config compilation failed with: {<p.config-core>}"
@@ -1296,7 +1231,7 @@
       (new-project-error (crip message))
     ::
     =/  config-result
-      (mule-slap-subject p.hair p.config-core %make-config)
+      (mule-slap-subject p.config-core (ream %make-config))
     ?:  ?=(%| -.config-result)
       =/  message=tape
         "failed to call +make-config arm: {<p.config-result>}"
@@ -1307,8 +1242,8 @@
       (new-project-error (crip message))
     ::
     =/  virtualships-to-sync-result
-      %^  mule-slap-subject  p.hair  p.config-core
-      %make-virtualships-to-sync
+      %+  mule-slap-subject  p.config-core
+      (ream %make-virtualships-to-sync)
     ?:  ?=(%| -.virtualships-to-sync-result)
       =/  message=tape
         %+  weld  "failed to call +make-virtualships-to-sync"
@@ -1320,8 +1255,7 @@
       (new-project-error (crip message))
     ::
     =/  install-result
-      %^  mule-slap-subject  p.hair  p.config-core
-      %make-install
+      (mule-slap-subject p.config-core (ream %make-install))
     ?:  ?=(%| -.install-result)
       =/  message=tape
         "failed to call +make-install arm: {<p.install-result>}"
@@ -1332,8 +1266,8 @@
       (new-project-error (crip message))
     ::
     =/  start-apps-result
-      %^  mule-slap-subject  p.hair  p.config-core
-      %make-start-apps
+      %+  mule-slap-subject  p.config-core
+      (ream %make-start-apps)
     ?:  ?=(%| -.start-apps-result)
       =/  message=tape
         %+  weld  "failed to call +make-start-apps arm:"
@@ -1345,8 +1279,7 @@
       (new-project-error (crip message))
     ::
     =/  setup-result
-      %^  mule-slap-subject  p.hair  p.config-core
-      %make-setup
+      (mule-slap-subject p.config-core (ream %make-setup))
     ?:  ?=(%| -.setup-result)
       =/  message=tape
         "failed to call +make-setup arm: {<p.setup-result>}"

--- a/lib/zink/conq.hoon
+++ b/lib/zink/conq.hoon
@@ -1,6 +1,6 @@
 /+  *zink-zink, smart=zig-sys-smart, engine=zig-sys-engine
 /*  smart-lib-noun  %noun  /lib/zig/sys/smart-lib/noun
-:: /*  triv-txt        %hoon  /con/trivial/hoon
+/*  triv-txt        %hoon  /con/trivial/hoon
 |%
 ::
 ++  hash
@@ -21,12 +21,14 @@
 ++  compile-path
   |=  pax=path
   ^-  [bat=* pay=*]
+  !.
   =/  desk=path  (swag [0 3] pax)
-  (compile-contract desk .^(@t %cx pax))
+  (compile-contract pax desk .^(@t %cx pax))
 ::
 ++  compile-contract
-  |=  [desk=path txt=@t]
+  |=  [pax=path desk=path txt=@t]
   ^-  [bat=* pay=*]
+  !.
   ::
   ::  goal flow:
   ::  - take main file, parse to find libs
@@ -40,7 +42,7 @@
   ::
   ::  parse contract code
   =/  [raw=(list [face=term =path]) contract-hoon=hoon]
-    (parse-pile (trip txt))
+    (parse-pile pax (trip txt))
   ::  generate initial subject containing uHoon
   =/  smart-lib=vase  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
   ::  compose libraries against uHoon subject
@@ -53,7 +55,7 @@
     :+  %ktts  face
     =/  lib-txt  .^(@t %cx (welp pax /hoon))
     ::  CURRENTLY IGNORING IMPORTS INSIDE LIBRARIES
-    +:(parse-pile (trip lib-txt))
+    +:(parse-pile pax (trip lib-txt))
   =/  pay=*  q:(~(mint ut p.smart-lib) %noun libraries)
   =/  payload=vase  (slap smart-lib libraries)
   =/  cont
@@ -62,126 +64,126 @@
   ::
   [bat=q.cont pay]
 ::
-:: ++  compile-trivial
-::   |=  [hoonlib-txt=@t smartlib-txt=@t]
-::   ^-  vase
-::   =/  [raw=(list [face=term =path]) contract-hoon=hoon]
-::     (parse-pile (trip triv-txt))
-::   =/  smart-lib=vase
-::     ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
-::   =/  libraries=hoon  [%clsg ~]
-::   =/  full-nock=*     q:(~(mint ut p.smart-lib) %noun libraries)
-::   =/  payload=vase    (slap smart-lib libraries)
-::   ::
-::   (slap (slop smart-lib payload) contract-hoon)
-:: ::
-:: ++  conq
-::   |=  [hoonlib-txt=@t smartlib-txt=@t cax=cache bud=@ud]
-::   ^-  (map * phash)
-::   |^
-::   =.  cax
-::     %-  ~(gas by cax)
-::     %+  turn  (gulf 0 12)
-::     |=  n=@
-::     ^-  [* phash]
-::     [n (hash n ~)]
-::   ~&  >>  %compiling
-::   =/  built-contract  (compile-trivial hoonlib-txt smartlib-txt)
-::   ~&  >>  %hashing-arms
-::   =.  cax
-::     %^  cache-file  built-contract
-::       cax
-::     :~  ::  hoon
-::         ::  four layers
-::         'add'
-::         'biff'
-::         'egcd'
-::         'po'
-::         ::  inner layers
-::         'dif:fe'
-::         'all:in'
-::         'all:by'
-::         'get:ja'
-::         'del:ju'
-::         'apt:to'
-::         'le:nl'
-::         'abs:si'
-::         'sb:ff'
-::         ::  smart
-::         ::  five layers
-::         'pedersen'
-::         'hash'
-::         'ship'
-::         'id'
-::         'big'
-::         ::  inner layers (reverse order)
-::         'as-octs:secp:crypto'
-::         'hmac-sha1:hmac:crypto'
-::         'keccak-224:keccak:crypto'
-::         'as:crub:crypto'
-::         'sal:scr:crypto'
-::         'ahem:aes:crypto'
-::         'aes:crypto'
-::         'as-octs:mimes:html'
-::         'mimes:html'
-::         'fu:number'
-::         'pass:ames'
-::         'hash:pedersen'
-::         't:pedersen'
-::         ::  'bif:bi'
-::         'frond:enjs:format'
-::     ==
-::   ~&  >>  %hashing-trivial-core
-::   ::
-::   ::  =/  [raw=(list [face=term =path]) contract-hoon=hoon]  (parse-pile (trip triv-txt))
-::   ::  =/  smart-lib=vase  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
-::   ::  =/  libraries=hoon  [%clsg ~]
-::   ::  =/  full-nock=*  q:(~(mint ut p.smart-lib) %noun libraries)
-::   ::  =/  payload=vase  (slap smart-lib libraries)
-::   ::  =/  cont  (~(mint ut p:(slop smart-lib payload)) %noun contract-hoon)
-::   ::  ::
-::   ::  =/  gun  (~(mint ut p.cont) %noun (ream '~'))
-::   ::  =/  =book  (zebra bud cax *chain-state-scry [q.cont q.gun] %.n)
-::   ::  ~&  p.book
-::   ::  cax.q.book
-::   ::
-::   =/  smart-lib=vase  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
-::   =/  code=[bat=* pay=*]  (compile-contract /zig triv-txt)
-::   =/  cor  .*([q.smart-lib pay.code] bat.code)
-::   =/  dor  [-:!>(*contract:smart) cor]
-::   =/  gun  (ajar:engine dor %write !>(*context:smart) !>(*calldata:smart) %$)
-::   =/  =book  (zebra bud cax *chain-state-scry gun %.n)
-::   ~&  p.book
-::   cax.q.book
-::   ::
-::   ++  cache-file
-::     |=  [vax=vase cax=cache layers=(list @t)]
-::     ^-  cache
-::     |-
-::     ?~  layers
-::       cax
-::     =/  cor  (slap vax (ream (cat 3 '..' i.layers)))
-::     =/  min  (~(mint ut p.vax) %noun (ream (cat 3 '..' i.layers)))
-::     $(layers t.layers, cax (hash-arms cor cax))
-::   ::
-::   ++  hash-arms
-::     |=  [vax=vase cax=(map * phash)]
-::     ^-  (map * phash)
-::     =/  lis  (sloe p.vax)
-::     =/  len  (lent lis)
-::     =/  i  1
-::     |-
-::     ?~  lis  cax
-::     =*  t  i.lis
-::     ~&  >  %-  crip
-::            %-  zing
-::            :~  (trip t)
-::                (reap (sub 20 (met 3 t)) ' ')
-::                (trip (rap 3 (scot %ud i) '/' (scot %ud len) ~))
-::            ==
-::     =/  n  q:(slot (arm-axis vax t) vax)
-::     $(lis t.lis, cax (~(put by cax) n (hash n cax)), i +(i))
-::   --
+++  compile-trivial
+  |=  [pax=path hoonlib-txt=@t smartlib-txt=@t]
+  ^-  vase
+  =/  [raw=(list [face=term =path]) contract-hoon=hoon]
+    (parse-pile /con/trivial/hoon (trip triv-txt))
+  =/  smart-lib=vase
+    ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
+  =/  libraries=hoon  [%clsg ~]
+  =/  full-nock=*     q:(~(mint ut p.smart-lib) %noun libraries)
+  =/  payload=vase    (slap smart-lib libraries)
+  ::
+  (slap (slop smart-lib payload) contract-hoon)
+::
+++  conq
+  |=  [pax=path hoonlib-txt=@t smartlib-txt=@t cax=cache bud=@ud]
+  ^-  (map * phash)
+  |^
+  =.  cax
+    %-  ~(gas by cax)
+    %+  turn  (gulf 0 12)
+    |=  n=@
+    ^-  [* phash]
+    [n (hash n ~)]
+  ~&  >>  %compiling
+  =/  built-contract  (compile-trivial pax hoonlib-txt smartlib-txt)
+  ~&  >>  %hashing-arms
+  =.  cax
+    %^  cache-file  built-contract
+      cax
+    :~  ::  hoon
+        ::  four layers
+        'add'
+        'biff'
+        'egcd'
+        'po'
+        ::  inner layers
+        'dif:fe'
+        'all:in'
+        'all:by'
+        'get:ja'
+        'del:ju'
+        'apt:to'
+        'le:nl'
+        'abs:si'
+        'sb:ff'
+        ::  smart
+        ::  five layers
+        'pedersen'
+        'hash'
+        'ship'
+        'id'
+        'big'
+        ::  inner layers (reverse order)
+        'as-octs:secp:crypto'
+        'hmac-sha1:hmac:crypto'
+        'keccak-224:keccak:crypto'
+        'as:crub:crypto'
+        'sal:scr:crypto'
+        'ahem:aes:crypto'
+        'aes:crypto'
+        'as-octs:mimes:html'
+        'mimes:html'
+        'fu:number'
+        'pass:ames'
+        'hash:pedersen'
+        't:pedersen'
+        ::  'bif:bi'
+        'frond:enjs:format'
+    ==
+  ~&  >>  %hashing-trivial-core
+  ::
+  ::  =/  [raw=(list [face=term =path]) contract-hoon=hoon]  (parse-pile /con/trivial/hoon (trip triv-txt))
+  ::  =/  smart-lib=vase  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
+  ::  =/  libraries=hoon  [%clsg ~]
+  ::  =/  full-nock=*  q:(~(mint ut p.smart-lib) %noun libraries)
+  ::  =/  payload=vase  (slap smart-lib libraries)
+  ::  =/  cont  (~(mint ut p:(slop smart-lib payload)) %noun contract-hoon)
+  ::  ::
+  ::  =/  gun  (~(mint ut p.cont) %noun (ream '~'))
+  ::  =/  =book  (zebra bud cax *chain-state-scry [q.cont q.gun] %.n)
+  ::  ~&  p.book
+  ::  cax.q.book
+  ::
+  =/  smart-lib=vase  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
+  =/  code=[bat=* pay=*]  (compile-contract /con/trivial/hoon /zig triv-txt)
+  =/  cor  .*([q.smart-lib pay.code] bat.code)
+  =/  dor  [-:!>(*contract:smart) cor]
+  =/  gun  (ajar:engine dor %write !>(*context:smart) !>(*calldata:smart) %$)
+  =/  =book  (zebra bud cax *chain-state-scry gun %.n)
+  ~&  p.book
+  cax.q.book
+  ::
+  ++  cache-file
+    |=  [vax=vase cax=cache layers=(list @t)]
+    ^-  cache
+    |-
+    ?~  layers
+      cax
+    =/  cor  (slap vax (ream (cat 3 '..' i.layers)))
+    =/  min  (~(mint ut p.vax) %noun (ream (cat 3 '..' i.layers)))
+    $(layers t.layers, cax (hash-arms cor cax))
+  ::
+  ++  hash-arms
+    |=  [vax=vase cax=(map * phash)]
+    ^-  (map * phash)
+    =/  lis  (sloe p.vax)
+    =/  len  (lent lis)
+    =/  i  1
+    |-
+    ?~  lis  cax
+    =*  t  i.lis
+    ~&  >  %-  crip
+           %-  zing
+           :~  (trip t)
+               (reap (sub 20 (met 3 t)) ' ')
+               (trip (rap 3 (scot %ud i) '/' (scot %ud len) ~))
+           ==
+    =/  n  q:(slot (arm-axis vax t) vax)
+    $(lis t.lis, cax (~(put by cax) n (hash n cax)), i +(i))
+  --
 ::  conq helpers
 ++  arm-axis
   |=  [vax=vase arm=term]
@@ -199,19 +201,20 @@
     ==
 +$  taut  [face=(unit term) pax=term]
 ++  parse-pile
-  |=  tex=tape
+  |=  [pax=path tex=tape]
   ^-  small-pile
-  =/  [=hair res=(unit [=small-pile =nail])]  (pile-rule [1 1] tex)
+  =/  [=hair res=(unit [=small-pile =nail])]  ((pile-rule pax) [1 1] tex)
   ?^  res  small-pile.u.res
   %-  mean  %-  flop
   =/  lyn  p.hair
   =/  col  q.hair
-  :~  leaf+"syntax error"
+  :~  leaf+"syntax error in {<pax>}"
       leaf+"\{{<lyn>} {<col>}}"
       leaf+(runt [(dec col) '-'] "^")
       leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
   ==
 ++  pile-rule
+  |=  pax=path
   %-  full
   %+  ifix
     :_  gay
@@ -223,7 +226,7 @@
     ;~(plug sym ;~(pfix gap stap))
   ::
     %+  stag  %tssg
-    (most gap tall:vast)
+    (most gap tall:(vang & (slag 3 pax)))
   ==
 ++  rune
   |*  [bus=rule fel=rule]

--- a/ted/ziggurat/test/run.hoon
+++ b/ted/ziggurat/test/run.hoon
@@ -79,8 +79,8 @@
     %-  pure:m
     [%| (cat 3 'scry failed: ' (crip (noah !>(payload))))]
   =/  compilation-result
-    %^  mule-slap-subject:zig-lib  0  subject
-    mold-name.payload
+    %+  mule-slap-subject:zig-lib  subject
+    (ream mold-name.payload)
   ?:  ?=(%| -.compilation-result)
     ~&  %ziggurat-test-run^%scry-compilation-fail^p.compilation-result
     %-  pure:m
@@ -115,8 +115,8 @@
     %-  pure:m
     [%| (cat 3 'dbug failed: ' (crip (noah !>(payload))))]
   =/  compilation-result
-    %^  mule-slap-subject:zig-lib  0  subject
-    mold-name.payload
+    %+  mule-slap-subject:zig-lib  subject
+    (ream mold-name.payload)
   ?:  ?=(%| -.compilation-result)
     ~&  %ziggurat-test-run^%dbug-compilation-fail^p.compilation-result
     %-  pure:m
@@ -163,8 +163,8 @@
   ?:  is-mar-found
     ::  found mark: proceed
     =/  compilation-result
-      %^  mule-slap-subject:zig-lib  0  subject
-      payload.payload
+      %+  mule-slap-subject:zig-lib  subject
+      (ream payload.payload)
     ?:  ?=(%| -.compilation-result)
       ~&  %ziggurat-test-run^%poke-compilation-fail^p.compilation-result
       %-  pure:m


### PR DESCRIPTION
**Problem**:

Compiler errors for test-steps, custom-step-definitions, configuration files are uninformative at best.

**Solution**:

Use `vang` to replace `vast`, as in #391 
Remove some old code that was trying to improve the bad situation but is no longer necessary now that we have real stack traces.

**Notes**:

This PR brings in #391 as well as some other changes. More compiler improvements to come, but I want to keep this fairly tightly scoped. This PR is working but I want to wait to review/merge it until #391 is merged so we can bring in any changes from there to here. If that PR is slow to merge I may change my mind.