### PR TITLE
ziggurat: speed up discretization

### DIFF
--- a/ted/ziggurat/test/run.hoon
+++ b/ted/ziggurat/test/run.hoon
@@ -273,12 +273,16 @@
   |=  [done-duration=@dr project-id=@t]
   =/  m  (strand:spider ,~)
   ^-  form:m
+  ;<  ~  bind:m  (sleep `@dr`1)
   |-
+  ;<  is-stack-empty=?  bind:m  get-is-stack-empty
+  ?.  is-stack-empty
+    ;<  ~  bind:m  (sleep (div ~s1 4))
+    $
   ;<  =bowl:strand  bind:m  get-bowl
   =*  now  now.bowl
   =/  timers=(list [@da duct])
-    %+  filter-timers  now
-    (get-virtualship-timers project-id [our now]:bowl)
+    (get-real-and-virtual-timers project-id [our now]:bowl)
   ?~  timers                                       (pure:m ~)
   =*  soonest-timer  -.i.timers
   ?:  (lth (add now done-duration) soonest-timer)  (pure:m ~)
@@ -286,20 +290,40 @@
   :: ~&  [%ztr %block now `(list [@da duct])`timers]
   $
 ::
-++  ignored-timer-prefixes
+++  get-is-stack-empty
+  =/  m  (strand:spider ,?)
+  ^-  form:m
+  ;<  maz=(list mass)  bind:m  (scry (list mass) /i//whey)  ::  sys/vane/iris/hoon:386
+  =/  by-id  (snag 2 maz)
+  ?^  p.q.by-id  (pure:m %.n)
+  (pure:m %.y)
+::
+++  ignored-virtualship-timer-prefixes
   ^-  (list path)
   :_  ~
   /ames/pump
 ::
+++  ignored-realship-timer-prefixes
+  ^-  (list path)
+  :~  /ames/pump
+      /gall/use/pyre
+      /gall/use/hark-system-hook
+      /gall/use/hark
+      /gall/use/notify
+  ==
+::
 ++  filter-timers
-  |=  [now=@da timers=(list [@da duct])]
+  |=  $:  now=@da
+          ignored-prefixes=(list path)
+          timers=(list [@da duct])
+      ==
   ^-  (list [@da duct])
   %+  murn  timers
   |=  [time=@da d=duct]
   ?~  d               `[time d]  ::  ?
   ?:  (gth now time)  ~
   =*  p  i.d
-  %+  roll  ignored-timer-prefixes
+  %+  roll  ignored-prefixes
   |:  [ignored-prefix=`path`/ timer=`(unit [@da duct])``[time d]]
   ?:  =(ignored-prefix (scag (lent ignored-prefix) p))  ~
   timer
@@ -310,8 +334,6 @@
   =/  now-ta=@ta  (scot %da now)
   =/  ships=(list @p)
     (get-virtualships-synced-for-project project-id our now)
-  %-  sort
-  :_  |=([a=(pair @da duct) b=(pair @da duct)] (lth p.a p.b))
   %+  roll  ships
   |=  [who=@p all-timers=(list [@da duct])]
   =/  who-ta=@ta  (scot %p who)
@@ -340,6 +362,25 @@
   =*  sync-desk-to-vship  p.payload.update
   ~(tap in (~(get ju sync-desk-to-vship) project-id))
 ::
+++  get-realship-timers
+  |=  [our=@p now=@da]
+  ^-  (list [@da duct])
+  .^  (list [@da duct])
+      %bx
+      /(scot %p our)//(scot %da now)/debug/timers
+  ==
+::
+++  get-real-and-virtual-timers
+  |=  [project-id=@t our=@p now=@da]
+  ^-  (list [@da duct])
+  %-  sort
+  :_  |=([a=(pair @da duct) b=(pair @da duct)] (lth p.a p.b))
+  %+  weld
+    %^  filter-timers  now  ignored-realship-timer-prefixes
+    (get-realship-timers our now)
+  %^  filter-timers  now  ignored-virtualship-timer-prefixes
+  (get-virtualship-timers project-id our now)
+::
 ++  run-steps
   |=  $:  project-id=@t
           test-id=@ux
@@ -356,7 +397,6 @@
     %-  slop  :_  subject
     results-vase(p [%face %test-results p.results-vase])
   |-
-  ;<  ~  bind:m  (sleep ~s1)  :: TODO: unhardcode; tune time to allow previous step to continue processing
   ;<  ~  bind:m  (block-on-previous-step ~m1 project-id)  :: TODO: unhardcode; are these good numbers?
   ;<  ~  bind:m
     ?~  snapshot-ships  (pure:(strand ,~) ~)


### PR DESCRIPTION
**Problem**:

Discretization is slow, primarily due to a `~s1` sleep before every step.

**Solution**:

Watch realship timers and iris requests to avoid having to `~s1` sleep every step.

**Notes**:

WIP