### PR TITLE
Release 0.1: remove excess prints, turn off verb for all apps

### DIFF
--- a/app/batcher-interval.hoon
+++ b/app/batcher-interval.hoon
@@ -21,7 +21,7 @@
 =|  state-0
 =*  state  -
 %-  agent:dbug
-%+  verb  |
+::  %+  verb  |
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .

--- a/app/faucet.hoon
+++ b/app/faucet.hoon
@@ -29,7 +29,7 @@
 =*  state  -
 ::
 %-  agent:dbug
-%+  verb  |
+::  %+  verb  |
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .

--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -135,7 +135,7 @@
 =*  state  -
 ::
 %-  agent:dbug
-%+  verb  |
+::  %+  verb  |
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/app/rollup.hoon
+++ b/app/rollup.hoon
@@ -19,7 +19,7 @@
 =*  state  -
 ::
 %-  agent:dbug
-%+  verb  |
+::  %+  verb  |
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .

--- a/app/sequencer.hoon
+++ b/app/sequencer.hoon
@@ -247,7 +247,7 @@
         %run-pending
       ?>  =(src.bowl our.bowl)
       ?:  =(~ pending)
-        ~&  >  "%sequencer: no pending txns to run"
+        ::  ~&  >  "%sequencer: no pending txns to run"
         `state
       ?~  town  ~|("%sequencer: error: no state" !!)
       =/  addr  p.sequencer.hall.u.town
@@ -315,8 +315,8 @@
     ::
         %perform-batch
       ?>  =(src.bowl our.bowl)
-      ~&  %perform-batch
-      ~>  %bout
+      ::  ~&  %perform-batch
+      ::  ~>  %bout
       ?.  =(%available status)
         ~|("%sequencer: error: got poke while not active" !!)
       ?~  town
@@ -324,7 +324,7 @@
       ?~  rollup
         ~|("%sequencer: error: no known rollup host" !!)
       ?:  =(~ memlist)
-        ~&  >  "%sequencer: ignoring batch trigger, no transactions"
+        ::  ~&  >  "%sequencer: ignoring batch trigger, no transactions"
         `state
       ?>  ?=(%full-publish -.mode.hall.u.town)
       ::  publish full diff data

--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -32,7 +32,7 @@
 =*  state  -
 ::
 %-  agent:dbug
-%+  verb  |
+::  %+  verb  |
 ^-  agent:gall
 =<
   |_  =bowl:gall

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -43,7 +43,7 @@
 =*  state  -
 ::
 %-  agent:dbug
-%+  verb  &
+::  %+  verb  |
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .
@@ -363,8 +363,8 @@
           ~|("%wallet: don't have private key for that address" !!)
         %+  ecdsa-raw-sign:secp256k1:secp:crypto
         `@uvI`hash  u.priv.u.keypair
-      ~&  >>  "%wallet: submitting signed transaction"
-      ~&  >>  "with signature {<v.sig.tx^r.sig.tx^s.sig.tx>}"
+      ::  ~&  >>  "%wallet: submitting signed transaction"
+      ::  ~&  >>  "with signature {<v.sig.tx^r.sig.tx^s.sig.tx>}"
       ::  update stores
       :_  %=    state
               pending-store


### PR DESCRIPTION
**Problem**:

Need to reduce verbosity for user-installed core

**Solution**:

Removing `verb` from all core apps + commenting out non-useful dojo prints.

