### PR TITLE
Wallet: add a poke for sharing address

### DIFF
--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -117,6 +117,7 @@
           %uqbar-action  (handle-action !<(action:u v))
           %uqbar-write   (handle-write !<(write:u v))
           %wallet-poke   handle-wallet-poke
+          %uqbar-share-address  handle-wallet-poke
       ==
     [cards this]
     ::

--- a/sur/zig/uqbar.hoon
+++ b/sur/zig/uqbar.hoon
@@ -26,6 +26,12 @@
       [%receipt tx-hash=hash:smart sequencer-receipt]  ::  from the sequencer
   ==
 ::
++$  share-address
+  $%  [%request app=term]
+      [%deny ~]
+      [%share =address:smart]
+  ==
+::
 ::  responses from sending a %submit poke
 ::
 +$  write-result

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -7,8 +7,19 @@
 +$  nft             nft:eng
 ::
 +$  signature   [p=@ux q=ship r=life]
+::
 ::  for app-generated transactions to be notified of their txn results
+::
 +$  origin  (unit (pair term wire))
+::
+::  for choosing which address to share if asked, if any
+::
++$  share-prefs
+  $~  [%any ~]  ::  default
+  $%  [%one =address:smart]  ::  specify which address we want to share
+      [%any ~]               ::  just grab any one address in our wallet
+      [%none ~]              ::  don't share uqbar addresses with anyone
+  ==
 ::
 ::  book: the primary map of assets that we track
 ::  supports fungibles and NFTs
@@ -124,6 +135,7 @@
       [%edit-nickname address=@ux nick=@t]
       [%sign-typed-message from=address:smart domain=id:smart type=json msg=*]
       [%add-tracked-address address=@ux nick=@t]
+      [%set-share-prefs =share-prefs]
       ::  testing and internal
       [%set-nonce address=@ux town=@ux new=@ud]
       [%approve-origin (pair term wire) gas=[rate=@ud bud=@ud]]


### PR DESCRIPTION
**Problem**:

For a lot of the UX flows we want to provide, it's important to be able to ask another ship for their uqbar address. In any long term view, this will be done by a remote-scry, and later probably an on-chain directory. But we need a simple immediate solution for sharing an Uqbar address programmatically.

**Solution**:

I've added a new item to the wallet state, `share-prefs`:
```hoon
+$  share-prefs
  $~  [%any ~]  ::  default
  $%  [%one =address:smart]
      [%any ~]
      [%none ~]
  ==
```

This tracks which address you want to share when asked, if any. It defaults to `%any`, which means the wallet will just pop whatever address is on the top of your map and share it with the requester. If you don't want to do this, you can change your preferences with this poke:
```hoon
:wallet &wallet-poke [%set-share-prefs =share-prefs]
```

In order to request the address of another ship, you poke their wallet (or `uqbar.hoon`, which will route these to any wallet!) with this:
```hoon
:uqbar &uqbar-share-address [%request %my-app]
```
where %my-app is the name of the Gall app that wants to receive the pokeback with the result. Once userspace permissions drops, hopefully we'll be able to remove this nonsense and just know the name of the app poking us.
