### PR TITLE
wallet: add tx-hash to receipt

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -182,7 +182,7 @@
         %+  ~(poke pass:io /receipt)
           [our.bowl p.u.origin.u.found]
         :-  %wallet-update
-        !>(`wallet-update`[%sequencer-receipt origin.u.found +.q.result])
+        !>(`wallet-update`[%sequencer-receipt origin.u.found p.result +.q.result])
       ==
     =^  cards  tokens
       ?.  ?=(%receipt -.q.result)  [cards tokens]

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -108,7 +108,7 @@
           action=supported-actions
       ==
       ::  poked back to origin after sequencer optimistically processes
-      [%sequencer-receipt =origin sequencer-receipt:uqbar]
+      [%sequencer-receipt =origin =hash:smart sequencer-receipt:uqbar]
       ::  poked back to origin when transaction is included in batch
       [%finished-transaction finished-transaction]
   ==


### PR DESCRIPTION
**Problem**:

Wallet doesn't pass on the tx-hash to app origin

**Solution**:

Include the hash in the wallet-update type

**Notes**:
.
