### PR TITLE
hotfix: engine: skip +charge on failed gas audit

### DIFF
--- a/lib/zig/sys/engine.hoon
+++ b/lib/zig/sys/engine.hoon
@@ -34,6 +34,9 @@
       ?~  output.i.pending
         =+  op=~(intake eng chain.st tx)
         ::  charge cumulative gas fee for entire transaction
+        ::  only charge gas fee if errorcode allows for it
+        ?:  |(=(%1 errorcode.op) =(%2 errorcode.op) =(%3 errorcode.op))
+          op
         =/  gas-item
           %-  ~(charge tax p.chain)
           [modified.op caller.tx gas.op]


### PR DESCRIPTION
**Problem**:

Execution engine refactor made it so that +charge arm was not getting properly skipped if a transaction failed gas audit

**Solution**:

Check errorcode on transaction output before calling charge

**Notes**:

Deployed immediately to testnet