### PR TITLE
sequencer/indexer: switch to remote scry for batch sharing

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -483,7 +483,7 @@
       !<  indexer-update:seq
       [-:!>(*indexer-update:seq) q.u.q.dat.u.roar.sign-arvo]
     ?>  ?=(%update -.upd)
-    ?>  =(town-id.hall.town.upd p.sequencer.hall)
+    ?>  =(town-id.hall.upd town-id.hall)
     ::  we made it, ingest the batch!
     =^  cards  state
       (consume-sequencer-update:ic upd)

--- a/app/sequencer.hoon
+++ b/app/sequencer.hoon
@@ -12,37 +12,6 @@
 /*  smart-lib-noun  %noun  /lib/zig/sys/smart-lib/noun
 |%
 +$  card  card:agent:gall
-+$  old-proposed-batch
-  [num=@ud =processed-txs =chain diff-hash=@ux root=@ux]
-+$  state-1
-  $:  %1
-      rollup=(unit ship)      ::  replace in future with ETH contract address
-      private-key=(unit @ux)  ::  our signing key
-      town=(unit town)        ::  chain-state
-      peer-roots=(map town=@ux root=@ux)  ::  track updates from rollup
-      pending=mempool         ::  unexecuted transactions
-      =memlist                ::  executed transactions in working state
-      proposed-batch=(unit old-proposed-batch)   ::  stores working state
-      status=?(%available %off)
-      block-height-api-key=(unit @t)
-  ==
-+$  inflated-state-1  [state-1 =eng smart-lib-vase=vase]
-::
-+$  state-2
-  $:  %2
-      last-batch-time=@da      ::  saved to compare against indexer acks
-      indexers=(map dock @da)  ::  indexers receiving batch updates
-      rollup=(unit ship)       ::  replace in future with ETH contract address
-      private-key=(unit @ux)   ::  our signing key
-      town=(unit town)         ::  chain-state
-      peer-roots=(map town=@ux root=@ux)  ::  track updates from rollup
-      pending=mempool          ::  unexecuted transactions
-      =memlist                 ::  executed transactions in working state
-      proposed-batch=(unit old-proposed-batch)   ::  stores working state
-      status=?(%available %off)
-      block-height-api-key=(unit @t)
-  ==
-+$  inflated-state-2  [state-2 =eng smart-lib-vase=vase]
 ::
 +$  state-3
   $:  %3
@@ -66,7 +35,7 @@
 =|  inflated-state-3
 =*  state  -
 %-  agent:dbug
-::  %+  verb  &
+%+  verb  &
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .
@@ -431,15 +400,24 @@
             working-batch    `batch
             pending-batch    `batch
           ==
+      ::  remote scry: only poke indexers with the hash of new batch.
+      ::  they will scry for the actual batch contents. NOTE:
+      ::  replace with sticky-scry / subscription once available.
+      ::  pin the actual batch to a path of its hash.
+      :-  :*  %pass  /pin-batch
+              %grow  /batch/(scot %ux town-id.hall.u.town)/(scot %ux root.batch)
+              :-  %sequencer-indexer-update
+              ^-  indexer-update
+              :^  %update  root.batch
+                processed-txs.batch
+              (transition-state u.town batch)
+          ==
       %+  turn   ~(tap by indexers)
       |=  [=dock @da]
       %+  ~(poke pass:io /indexer-updates)
         dock
       :-  %sequencer-indexer-update
-      !>  ^-  indexer-update
-      :^  %update  root.batch
-        processed-txs.batch
-      (transition-state u.town batch)
+      !>(`indexer-update`[%notify town-id.hall.u.town root.batch])
     ==
   --
 ::

--- a/app/sequencer.hoon
+++ b/app/sequencer.hoon
@@ -35,7 +35,7 @@
 =|  inflated-state-3
 =*  state  -
 %-  agent:dbug
-%+  verb  &
+::  %+  verb  &
 ^-  agent:gall
 |_  =bowl:gall
 +*  this  .
@@ -417,7 +417,12 @@
       %+  ~(poke pass:io /indexer-updates)
         dock
       :-  %sequencer-indexer-update
-      !>(`indexer-update`[%notify town-id.hall.u.town root.batch])
+      ?.  =(p.dock our.bowl)
+        !>(`indexer-update`[%notify town-id.hall.u.town root.batch])
+      !>  ^-  indexer-update
+      :^  %update  root.batch
+        processed-txs.batch
+      (transition-state u.town batch)
     ==
   --
 ::

--- a/sur/zig/sequencer.hoon
+++ b/sur/zig/sequencer.hoon
@@ -104,5 +104,39 @@
 ::  indexer must verify root is posted to rollup before verifying new state
 ::  pair of [transactions town] is batch from sur/indexer.hoon
 +$  indexer-update
-  [%update root=@ux transactions=processed-txs town]
+  $%  [%notify town=id:smart root=@ux]
+      [%update root=@ux transactions=processed-txs town]
+  ==
+::
+::  historical states
+::
++$  old-proposed-batch
+  [num=@ud =processed-txs =chain diff-hash=@ux root=@ux]
++$  state-1
+  $:  %1
+      rollup=(unit ship)      ::  replace in future with ETH contract address
+      private-key=(unit @ux)  ::  our signing key
+      town=(unit town)        ::  chain-state
+      peer-roots=(map town=@ux root=@ux)  ::  track updates from rollup
+      pending=mempool         ::  unexecuted transactions
+      =memlist                ::  executed transactions in working state
+      proposed-batch=(unit old-proposed-batch)   ::  stores working state
+      status=?(%available %off)
+      block-height-api-key=(unit @t)
+  ==
+::
++$  state-2
+  $:  %2
+      last-batch-time=@da      ::  saved to compare against indexer acks
+      indexers=(map dock @da)  ::  indexers receiving batch updates
+      rollup=(unit ship)       ::  replace in future with ETH contract address
+      private-key=(unit @ux)   ::  our signing key
+      town=(unit town)         ::  chain-state
+      peer-roots=(map town=@ux root=@ux)  ::  track updates from rollup
+      pending=mempool          ::  unexecuted transactions
+      =memlist                 ::  executed transactions in working state
+      proposed-batch=(unit old-proposed-batch)   ::  stores working state
+      status=?(%available %off)
+      block-height-api-key=(unit @t)
+  ==
 --


### PR DESCRIPTION
**Problem**:

Sharing batch data from sequencer to indexers takes too long

**Solution**:

Use remote scry!

