### PR TITLE
wallet: sign typed messages with shag:smart instead of sham

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -333,7 +333,7 @@
       ::  add pending signed-messages tab to frontend
       =/  keypair  (~(got by keys.state) from.act)
       =/  =typed-message:smart  [domain.act `@ux`(sham type.act) msg.act]
-      =/  hash  (sham typed-message)
+      =/  hash  `@uvI`(shag:smart typed-message)
       =/  signature
         ?~  priv.keypair
           ::  put it into some temporary thing for cold storage. Make it pending


### PR DESCRIPTION
In a contract context we use mostly petersen hashes, and the fungible, zigs, multisig contracts are using ++ recover from smart.hoon to recover a public key from a signed message and a signature.

Currently the wallet hashes the entire typed message with sham instead of shag.