### PR TITLE
engine: add scries to abstract-combust

### DIFF
--- a/ted/transaction-sim.hoon
+++ b/ted/transaction-sim.hoon
@@ -22,7 +22,7 @@
 |-  ^-  form:m
 =/  eng
   %~  engine  engine
-  :+  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
+  :+  !<(vase [-:!>(*vase) (cue q.q.smart-lib-noun)])  ::  ;;(vase (cue +.+:;;([* * @] smart-lib-noun)))
   jets:zink  %.n  ::  sigs off
 ::
 =*  gather-tests  $


### PR DESCRIPTION
**Problem**:

%validate calls *do* need scries, since otherwise it's quite impossible to build account contracts that can be non-hardcoded

**Solution**:

add search scry back into +abstract-combust

also, increased fixed gas limit to `30.000` to handle multisig -- can raise this further, too.