### PR TITLE
wallet: add %unsigned-transaction poke

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -541,6 +541,43 @@
         pending-store  (~(put by pending-store) from.act my-pending)
       ==
     ::
+        %unsigned-transaction
+      =/  =caller:smart
+        :+  0x0
+          0
+        :: zigs account of contract?
+        (hash-data:engine zigs-contract-id:smart contract.act town.act `@`'zigs')
+      ::  build calldata of transaction, depending on argument type
+      =/  =calldata:smart
+          ;;(calldata:smart +.action.act)
+      ::  
+      =/  =shell:smart
+        :*  caller
+            eth-hash=~
+            to=contract.act
+            gas=gas.act
+            town.act
+            status=%101
+        ==
+      ::  generate hash
+      =/  hash  (hash-transaction [calldata shell])
+      =/  tx=transaction:smart  [[0 0 0] calldata shell]
+      ~&  >>  "%wallet: submitting unsigned tx with hash {<hash>}"
+      ::  update stores
+      :_  %=    state
+              unfinished-transaction-store
+            %+  ~(put by unfinished-transaction-store)
+              hash
+            [origin.act tx action.act ~]
+          ==
+      :~  (tx-update-card hash tx action.act)
+          :*  %pass  /submit-tx/(scot %ux hash)
+              %agent  [our.bowl %uqbar]
+              %poke  %uqbar-write
+              !>(`write:uqbar`[%submit tx])
+          ==
+      ==
+    ::
         %transaction-to-ship
       ::  instead of making transaction, poke thread that will ask ship
       ::  for an address, then re-poke wallet with filled in info

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -407,8 +407,7 @@
               %agent  [our.bowl %uqbar]
               %poke  %uqbar-write
               !>(`write:uqbar`[%submit tx])
-          ==
-      ==
+      ==  ==
     ::
         %submit
       ::  sign a pending transaction from this hot wallet
@@ -416,6 +415,30 @@
       =/  my-pending  (~(got by pending-store) from.act)
       ?~  found=(~(get by my-pending) hash.act)
         ~|("%wallet: can't find pending transaction with that hash" !!)
+      ?:  =(0x0 from.act)
+        ::  submit an unsigned message, account abstracted contract pays for gas
+        =*  tx  transaction.u.found
+        =:  rate.gas.tx      rate.gas.act
+            bud.gas.tx       bud.gas.act
+            status.tx        %101
+        ==
+        ::  update hash of tx with new values
+        =/  hash  (hash-transaction +.tx)
+        :_  %=    state
+                pending-store
+              (~(put by pending-store) from.act (~(del by my-pending) hash.act))
+            ::
+                unfinished-transaction-store
+              %+  ~(put by unfinished-transaction-store)
+                hash
+              [origin.u.found tx action.u.found ~]
+            ==
+        :~  (tx-update-card hash tx action.u.found)
+            :*  %pass  /submit-tx/(scot %ux hash)
+                %agent  [our.bowl %uqbar]
+                %poke  %uqbar-write
+                !>(`write:uqbar`[%submit tx])
+        ==  ==
       ?~  keypair=(~(get by keys.state) from.act)
         ~|("%wallet: don't have knowledge of that address" !!)
       =*  tx  transaction.u.found
@@ -456,8 +479,7 @@
               %agent  [our.bowl %uqbar]
               %poke  %uqbar-write
               !>(`write:uqbar`[%submit tx])
-          ==
-      ==
+      ==  ==
     ::
         %delete-pending
       ~|  "%wallet: no pending transactions from that address"
@@ -542,40 +564,29 @@
       ==
     ::
         %unsigned-transaction
-      =/  =caller:smart
-        :+  0x0
-          0
-        :: zigs account of contract?
-        (hash-data:engine zigs-contract-id:smart contract.act town.act `@`'zigs')
       ::  build calldata of transaction, depending on argument type
-      =/  =calldata:smart
-          ;;(calldata:smart +.action.act)
-      ::  
-      =/  =shell:smart
-        :*  caller
-            eth-hash=~
-            to=contract.act
-            gas=gas.act
-            town.act
-            status=%101
-        ==
+      =/  =calldata:smart  +.action.act
+      =/  =shell:smart  [[0x0 0 0x0] ~ contract.act [0 0] town.act %100]
       ::  generate hash
       =/  hash  (hash-transaction [calldata shell])
-      =/  tx=transaction:smart  [[0 0 0] calldata shell]
+      =/  =transaction:smart  [[0 0 0] calldata shell]
       ~&  >>  "%wallet: submitting unsigned tx with hash {<hash>}"
       ::  update stores
-      :_  %=    state
-              unfinished-transaction-store
-            %+  ~(put by unfinished-transaction-store)
-              hash
-            [origin.act tx action.act ~]
+      =/  my-pending
+        %+  ~(put by (~(gut by pending-store) 0x0 ~))
+        hash  [origin.act transaction action.act]
+      :-  :-  (tx-update-card hash transaction action.act)
+          ?~  origin.act  ~
+          ?~  gas=(~(get by approved-origins) u.origin.act)  ~
+          :_  ~
+          :*  %pass  /self-submit
+              %agent  [our.bowl %wallet]
+              %poke  %wallet-poke
+              !>  ^-  wallet-poke
+              [%submit 0x0 hash u.gas]
           ==
-      :~  (tx-update-card hash tx action.act)
-          :*  %pass  /submit-tx/(scot %ux hash)
-              %agent  [our.bowl %uqbar]
-              %poke  %uqbar-write
-              !>(`write:uqbar`[%submit tx])
-          ==
+      %=  state
+        pending-store  (~(put by pending-store) 0x0 my-pending)
       ==
     ::
         %transaction-to-ship

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -565,7 +565,22 @@
     ::
         %unsigned-transaction
       ::  build calldata of transaction, depending on argument type
-      =/  =calldata:smart  +.action.act
+      =/  =calldata:smart
+        ?-    -.action.act
+            %noun
+          +.action.act
+        ::    
+            %text
+          =/  smart-lib-vase
+            .^  ^vase  %gx
+              /(scot %p our.bowl)/sequencer/(scot %da now.bowl)/smart-lib/noun
+            ==
+          ~|  "wallet: failed to compile custom action!"
+          =/  data-hoon  (ream ;;(@t +.action.act))
+          =/  res
+            (slap smart-lib-vase data-hoon)
+          !<([@tas *] res)
+        ==
       =/  =shell:smart  [[0x0 0 0x0] ~ contract.act [0 0] town.act %100]
       ::  generate hash
       =/  hash  (hash-transaction [calldata shell])

--- a/mar/wallet/poke.hoon
+++ b/mar/wallet/poke.hoon
@@ -10,8 +10,8 @@
     %-  wallet-poke
     |^
     =/  procd  (process jon)
-    ?.  ?=(%transaction -.procd)  procd
-    [%transaction origin=~ +.procd]
+    ?.  ?=(?(%transaction %unsigned-transaction) -.procd)  procd
+    [-.procd origin=~ +.procd]
     ++  process
       %-  of
       :~  [%import-seed (ot ~[[%mnemonic so] [%password so] [%nick so]])]
@@ -25,6 +25,7 @@
           [%submit parse-submit]
           [%delete-pending parse-delete]
           [%transaction parse-transaction]
+          [%unsigned-transaction parse-unsigned]
       ==
     ++  parse-signed
       %-  ot
@@ -44,6 +45,12 @@
       %-  ot
       :~  [%from (se %ux)]
           [%hash (se %ux)]
+      ==
+    ++  parse-unsigned
+      %-  ot
+      :~  [%contract (se %ux)]
+          [%town (se %ux)]
+          [%action (of ~[[%text so]])]
       ==
     ++  parse-transaction
       %-  ot

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -170,6 +170,13 @@
           town=@ux
           action=supported-actions
       ==
+      $:  %unsigned-transaction
+          =origin
+          contract=id:smart
+          town=@ux
+          gas=[rate=@ud bud=@ud]
+          action=[%noun [%validate *]]
+      ==
       ::
       $:  %transaction-to-ship
           =origin

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -174,7 +174,6 @@
           =origin
           contract=id:smart
           town=@ux
-          gas=[rate=@ud bud=@ud]
           action=[%noun [%validate *]]
       ==
       ::

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -174,7 +174,7 @@
           =origin
           contract=id:smart
           town=@ux
-          action=[%noun [%validate *]]
+          action=$%([%noun [%validate *]] [%text @t])
       ==
       ::
       $:  %transaction-to-ship


### PR DESCRIPTION
With account abstraction, we can have a contract pay gas and not sign or worry about signatures. Add a poke for it in wallet so other apps can use it and get back receipts. 

Could bake into the normal %transaction method and put in pending-store, but not pretty. 

Small error in on-agent jab py transaction store. 