### PR TITLE
engine: reproduce & validate eth-hashes for transactions

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -485,10 +485,10 @@
       ::  take in a new pending transaction
       =/  =caller:smart
         :+  from.act
-          ::  this is an ephemeral nonce used to differentiate between
-          ::  pending transactions. the real on-chain nonce is assigned
-          ::  upon signing.
-          `@ud`(cut 3 [0 3] eny.bowl)
+          ::  if there are several pending txs from the same address,
+          ::  cannot sign them one after another [fix]
+          =/  our-nonces  (~(gut by nonces.state) from.act ~)
+          +((~(gut by our-nonces) town.act 0))
         ::  generate our zigs token account ID
         (hash-data:engine zigs-contract-id:smart from.act town.act `@`'zigs')
       ::  build calldata of transaction, depending on argument type

--- a/lib/zig/sys/engine.hoon
+++ b/lib/zig/sys/engine.hoon
@@ -732,27 +732,30 @@
 ::  eth signature reproduction tools, for eth_personal_sign
 ::
 ++  build-eth-signature-string
-  |=  tx=transaction:smart
+  |=  [tx=transaction:smart old-hash=@ux]
   ^-  tape
-  =/  original-hash  (sham +.tx)
   %+  weld  "\19Ethereum Signed Message:\0a"         :: eth signed message prefix
   =-  "{<(lent -)>}{-}"                              :: len(msg) + msg
   %+  weld  "Contract: {<contract.tx>}\0a"
+  %+  weld  "From: {<address.caller.tx>}\0a"
   %+  weld  "Nonce: {<nonce.caller.tx>}\0a"   
   %+  weld  "Town: {<town.tx>}\0a"
-  %+  weld  "Rate: {<rate.gas.tx}\0a"
+  %+  weld  "Rate: {<rate.gas.tx>}\0a"
   %+  weld  "Budget: {<bud.gas.tx>}\0a"
-            "Data: {<original-hash>}"
+            "Data: {<old-hash>}"
 ::
 ++  generate-eth-tx-hash
   |=  tx=transaction:smart
-  ^-  @ux 
-  =:  eth-hash.tx  ~
-      gas.tx       [0 0]
+  ^-  @ux
+  =/  old  tx 
+  =:  eth-hash.old  ~
+      gas.old       [0 0]
+      status.old    %100
   ==
+  =/  original-hash  `@ux`(sham +.old)
   %-  keccak-256:keccak:crypto
   %-  as-octt:mimes:html
-  (build-eth-signature-string tx)      
+  (build-eth-signature-string tx original-hash)    
 ::
 ++  verify-sig
   |=  tx=transaction:smart

--- a/lib/zig/sys/engine.hoon
+++ b/lib/zig/sys/engine.hoon
@@ -729,13 +729,38 @@
   ^-  @ux  %-  shag:merk
   :((cury cat 3) town source holder salt)
 ::
+::  eth signature reproduction tools, for eth_personal_sign
+::
+++  build-eth-signature-string
+  |=  tx=transaction:smart
+  ^-  tape
+  =/  original-hash  (sham +.tx)
+  %+  weld  "\19Ethereum Signed Message:\0a"         :: eth signed message prefix
+  =-  "{<(lent -)>}{-}"                              :: len(msg) + msg
+  %+  weld  "Contract: {<contract.tx>}\0a"
+  %+  weld  "Nonce: {<nonce.caller.tx>}\0a"   
+  %+  weld  "Town: {<town.tx>}\0a"
+  %+  weld  "Rate: {<rate.gas.tx}\0a"
+  %+  weld  "Budget: {<bud.gas.tx>}\0a"
+            "Data: {<original-hash>}"
+::
+++  generate-eth-tx-hash
+  |=  tx=transaction:smart
+  ^-  @ux 
+  =:  eth-hash.tx  ~
+      gas.tx       [0 0]
+  ==
+  %-  keccak-256:keccak:crypto
+  %-  as-octt:mimes:html
+  (build-eth-signature-string tx)      
+::
 ++  verify-sig
   |=  tx=transaction:smart
   ^-  ?
   =/  hash=@
     ?~  eth-hash.tx
       (sham +.tx)
-    u.eth-hash.tx
+    (generate-eth-tx-hash tx)
   =?  v.sig.tx  (gte v.sig.tx 27)  (sub v.sig.tx 27)
   =?  hash  (gth (met 3 hash) 32)  (end [3 32] hash)
   =/  virt=toon


### PR DESCRIPTION
when a tx gets signed from an external eth wallet, hash and verify it in engine too. 

this awaits some changes in UI to clean up the string that gets signed.
related with signed-type-messages: https://github.com/uqbar-dao/uqbar-core/pull/478

add tests to lib/engine [x]